### PR TITLE
feat: ClockSource adapter

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
     "vitest": "^4.0.18"
   },
   "dependencies": {
-    "chokidar": "^4.0.0"
+    "chokidar": "^4.0.0",
+    "croner": "^9.0.0"
   },
   "engines": {
     "node": ">=22"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       chokidar:
         specifier: ^4.0.0
         version: 4.0.3
+      croner:
+        specifier: ^9.0.0
+        version: 9.1.0
     devDependencies:
       '@types/node':
         specifier: ^22.0.0
@@ -501,6 +504,10 @@ packages:
   consola@3.4.2:
     resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
     engines: {node: ^14.18.0 || >=16.10.0}
+
+  croner@9.1.0:
+    resolution: {integrity: sha512-p9nwwR4qyT5W996vBZhdvBCnMhicY5ytZkR4D1Xj0wuTDEiMnjwR57Q3RXYY/s0EpX6Ay3vgIcfaR+ewGHsi+g==}
+    engines: {node: '>=18.0'}
 
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
@@ -1146,6 +1153,8 @@ snapshots:
   confbox@0.1.8: {}
 
   consola@3.4.2: {}
+
+  croner@9.1.0: {}
 
   debug@4.4.3:
     dependencies:

--- a/src/clock/bridge.test.ts
+++ b/src/clock/bridge.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect, vi } from "vitest";
+import { createBridgeClock } from "./bridge.js";
+import type { Tick } from "./types.js";
+
+describe("createBridgeClock", () => {
+  it("starts with seq 0", () => {
+    const clock = createBridgeClock();
+    expect(clock.seq).toBe(0);
+    expect(clock.running).toBe(false);
+  });
+
+  it("throws if started twice", () => {
+    const clock = createBridgeClock();
+    clock.start(() => {});
+    expect(() => clock.start(() => {})).toThrow("Clock already running");
+  });
+
+  describe("push()", () => {
+    it("fires one tick per push", () => {
+      const clock = createBridgeClock();
+      const ticks: Tick[] = [];
+      clock.start((tick) => { ticks.push(tick); });
+
+      clock.push();
+      clock.push();
+      clock.push();
+
+      expect(ticks).toHaveLength(3);
+      expect(ticks[0]!.seq).toBe(0);
+      expect(ticks[1]!.seq).toBe(1);
+      expect(ticks[2]!.seq).toBe(2);
+      expect(ticks[0]!.reason).toBe("bridge");
+    });
+
+    it("ticks have real timestamps", () => {
+      const clock = createBridgeClock();
+      const ticks: Tick[] = [];
+      clock.start((tick) => { ticks.push(tick); });
+
+      const before = Date.now();
+      clock.push();
+      const after = Date.now();
+
+      expect(ticks[0]!.ts).toBeGreaterThanOrEqual(before);
+      expect(ticks[0]!.ts).toBeLessThanOrEqual(after);
+    });
+
+    it("is a no-op when not running", () => {
+      const clock = createBridgeClock();
+      const handler = vi.fn();
+      // Don't start
+      clock.push();
+      expect(handler).not.toHaveBeenCalled();
+    });
+
+    it("is a no-op after stop", () => {
+      const clock = createBridgeClock();
+      const ticks: Tick[] = [];
+      clock.start((tick) => { ticks.push(tick); });
+
+      clock.push();
+      clock.stop();
+      clock.push();
+
+      expect(ticks).toHaveLength(1);
+    });
+  });
+
+  describe("now()", () => {
+    it("returns real time (Date.now())", () => {
+      const clock = createBridgeClock();
+      const before = Date.now();
+      const now = clock.now();
+      const after = Date.now();
+      expect(now).toBeGreaterThanOrEqual(before);
+      expect(now).toBeLessThanOrEqual(after);
+    });
+  });
+
+  describe("stats", () => {
+    it("tracks tick count", () => {
+      const clock = createBridgeClock();
+      clock.start(() => {});
+      clock.push();
+      clock.push();
+
+      const stats = clock.stats();
+      expect(stats.tickCount).toBe(2);
+      expect(stats.droppedTicks).toBe(0);
+      expect(stats.errors).toBe(0);
+    });
+
+    it("tracks errors from sync handlers", () => {
+      const clock = createBridgeClock();
+      clock.start(() => { throw new Error("boom"); });
+
+      // push should not throw — bridge swallows errors
+      expect(() => clock.push()).not.toThrow();
+
+      const stats = clock.stats();
+      expect(stats.errors).toBe(1);
+      expect(stats.tickCount).toBe(1);
+    });
+
+    it("resets stats on restart", () => {
+      const clock = createBridgeClock();
+      clock.start(() => {});
+      clock.push();
+      clock.push();
+      clock.stop();
+
+      clock.start(() => {});
+      const stats = clock.stats();
+      expect(stats.tickCount).toBe(0);
+    });
+  });
+
+  describe("lifecycle", () => {
+    it("stop is idempotent", () => {
+      const clock = createBridgeClock();
+      clock.start(() => {});
+      clock.stop();
+      clock.stop();
+      expect(clock.running).toBe(false);
+    });
+
+    it("can restart after stop", () => {
+      const clock = createBridgeClock();
+      const ticks1: Tick[] = [];
+      const ticks2: Tick[] = [];
+
+      clock.start((tick) => { ticks1.push(tick); });
+      clock.push();
+      clock.stop();
+
+      clock.start((tick) => { ticks2.push(tick); });
+      clock.push();
+      clock.stop();
+
+      expect(ticks1).toHaveLength(1);
+      expect(ticks2).toHaveLength(1);
+      // Restart resets seq
+      expect(ticks2[0]!.seq).toBe(0);
+    });
+  });
+});

--- a/src/clock/bridge.ts
+++ b/src/clock/bridge.ts
@@ -1,0 +1,122 @@
+import type { Clock, Tick, TickHandler, TickStats } from "./types.js";
+
+/** Clock that ticks on external push() calls. */
+export interface BridgeClock extends Clock {
+  /** Push a tick from an external system. Each push = one tick. */
+  push(reason?: string): void;
+}
+
+/**
+ * Create a bridge clock driven by external events.
+ *
+ * - Every `push()` = one tick with reason "bridge"
+ * - No interval config — timing comes from external system
+ * - `now()` returns `Date.now()` (real time, not virtual)
+ */
+export function createBridgeClock(): BridgeClock {
+  let handler: TickHandler | null = null;
+  let _running = false;
+  let _seq = 0;
+
+  // Stats
+  let tickCount = 0;
+  let errors = 0;
+  let totalHandlerMs = 0;
+  let lastTickAt = 0;
+  let maxHandlerMs = 0;
+
+  const clock: BridgeClock = {
+    start(h: TickHandler): void {
+      if (_running) {
+        throw new Error("Clock already running");
+      }
+      handler = h;
+      _running = true;
+      _seq = 0;
+      tickCount = 0;
+      errors = 0;
+      totalHandlerMs = 0;
+      lastTickAt = 0;
+      maxHandlerMs = 0;
+    },
+
+    stop(): void {
+      _running = false;
+      handler = null;
+    },
+
+    now(): number {
+      return Date.now();
+    },
+
+    stats(): TickStats {
+      return {
+        tickCount,
+        droppedTicks: 0, // Bridge never drops — every push is a tick
+        errors,
+        avgHandlerMs: tickCount > 0 ? totalHandlerMs / tickCount : 0,
+        avgDriftMs: 0, // No concept of drift — timing is external
+        lastTickAt,
+        maxHandlerMs,
+      };
+    },
+
+    get running(): boolean {
+      return _running;
+    },
+
+    get seq(): number {
+      return _seq;
+    },
+
+    push(_reason?: string): void {
+      if (!_running || !handler) return;
+
+      const tick: Tick = {
+        ts: Date.now(),
+        seq: _seq++,
+        reason: "bridge",
+      };
+
+      tickCount++;
+      lastTickAt = tick.ts;
+
+      const start = Date.now();
+      let result: void | Promise<void>;
+      try {
+        result = handler(tick);
+      } catch (err) {
+        errors++;
+        const elapsed = Date.now() - start;
+        totalHandlerMs += elapsed;
+        if (elapsed > maxHandlerMs) maxHandlerMs = elapsed;
+        void err;
+        return;
+      }
+
+      // Handle async handlers
+      if (result && typeof result === "object" && "then" in result) {
+        (result as Promise<void>).then(
+          () => {
+            const elapsed = Date.now() - start;
+            totalHandlerMs += elapsed;
+            if (elapsed > maxHandlerMs) maxHandlerMs = elapsed;
+          },
+          (err) => {
+            errors++;
+            const elapsed = Date.now() - start;
+            totalHandlerMs += elapsed;
+            if (elapsed > maxHandlerMs) maxHandlerMs = elapsed;
+            void err;
+          },
+        );
+      } else {
+        const elapsed = Date.now() - start;
+        totalHandlerMs += elapsed;
+        if (elapsed > maxHandlerMs) maxHandlerMs = elapsed;
+      }
+    },
+  };
+
+  return clock;
+}

--- a/src/clock/interval.test.ts
+++ b/src/clock/interval.test.ts
@@ -1,0 +1,200 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { createIntervalClock } from "./interval.js";
+import type { Tick } from "./types.js";
+
+describe("createIntervalClock", () => {
+  let clock: ReturnType<typeof createIntervalClock>;
+
+  afterEach(() => {
+    clock?.stop();
+  });
+
+  it("throws if intervalMs is not positive", () => {
+    expect(() => createIntervalClock({ intervalMs: 0 })).toThrow("intervalMs must be positive");
+    expect(() => createIntervalClock({ intervalMs: -1 })).toThrow("intervalMs must be positive");
+  });
+
+  it("throws if started twice", () => {
+    clock = createIntervalClock({ intervalMs: 100 });
+    clock.start(() => {});
+    expect(() => clock.start(() => {})).toThrow("Clock already running");
+  });
+
+  describe("block policy (default)", () => {
+    it("fires ticks at interval", async () => {
+      clock = createIntervalClock({ intervalMs: 50 });
+      const ticks: Tick[] = [];
+
+      clock.start((tick) => {
+        ticks.push(tick);
+      });
+
+      expect(clock.running).toBe(true);
+      await sleep(180);
+      clock.stop();
+
+      expect(ticks.length).toBeGreaterThanOrEqual(2);
+      expect(ticks[0]!.seq).toBe(0);
+      expect(ticks[0]!.reason).toBe("interval");
+      // Sequences are monotonic
+      for (let i = 1; i < ticks.length; i++) {
+        expect(ticks[i]!.seq).toBe(ticks[i - 1]!.seq + 1);
+      }
+    });
+
+    it("waits for handler before scheduling next tick", async () => {
+      clock = createIntervalClock({ intervalMs: 30 });
+      const ticks: Tick[] = [];
+
+      clock.start(async (tick) => {
+        ticks.push(tick);
+        await sleep(60); // Handler takes 2x the interval
+      });
+
+      await sleep(250);
+      clock.stop();
+
+      // With block policy and 60ms handler + 30ms interval = ~90ms per tick
+      // In 250ms we should get ~2-3 ticks, not 8+ like fixed-rate would
+      expect(ticks.length).toBeLessThanOrEqual(4);
+      expect(ticks.length).toBeGreaterThanOrEqual(2);
+    });
+  });
+
+  describe("drop policy", () => {
+    it("drops ticks when handler is busy", async () => {
+      clock = createIntervalClock({ intervalMs: 30, backpressure: "drop" });
+      const ticks: Tick[] = [];
+
+      clock.start(async (tick) => {
+        ticks.push(tick);
+        if (tick.seq === 0) {
+          await sleep(100); // First handler blocks for multiple intervals
+        }
+      });
+
+      await sleep(200);
+      clock.stop();
+
+      const stats = clock.stats();
+      expect(stats.droppedTicks).toBeGreaterThan(0);
+    });
+  });
+
+  describe("adaptive policy", () => {
+    it("self-corrects timing after slow handler", async () => {
+      clock = createIntervalClock({ intervalMs: 40, backpressure: "adaptive" });
+      const ticks: Tick[] = [];
+
+      clock.start(async (tick) => {
+        ticks.push(tick);
+        if (tick.seq === 0) {
+          await sleep(60); // First tick takes longer
+        }
+      });
+
+      await sleep(300);
+      clock.stop();
+
+      // Adaptive should fire catch-up ticks
+      const catchups = ticks.filter((t) => t.reason === "catchup");
+      // May or may not have catch-ups depending on timing, but should have ticks
+      expect(ticks.length).toBeGreaterThanOrEqual(3);
+    });
+  });
+
+  describe("lifecycle", () => {
+    it("stop is idempotent", () => {
+      clock = createIntervalClock({ intervalMs: 100 });
+      clock.start(() => {});
+      clock.stop();
+      clock.stop(); // Should not throw
+      expect(clock.running).toBe(false);
+    });
+
+    it("can restart after stop", async () => {
+      clock = createIntervalClock({ intervalMs: 30 });
+      const ticks1: Tick[] = [];
+      const ticks2: Tick[] = [];
+
+      clock.start((tick) => ticks1.push(tick));
+      await sleep(80);
+      clock.stop();
+
+      clock.start((tick) => ticks2.push(tick));
+      await sleep(80);
+      clock.stop();
+
+      expect(ticks1.length).toBeGreaterThanOrEqual(1);
+      expect(ticks2.length).toBeGreaterThanOrEqual(1);
+      // Second start resets seq to 0
+      expect(ticks2[0]!.seq).toBe(0);
+    });
+  });
+
+  describe("stats", () => {
+    it("tracks tick count and handler duration", async () => {
+      clock = createIntervalClock({ intervalMs: 30 });
+
+      clock.start(async () => {
+        await sleep(5);
+      });
+
+      await sleep(120);
+      clock.stop();
+
+      const stats = clock.stats();
+      expect(stats.tickCount).toBeGreaterThanOrEqual(2);
+      expect(stats.avgHandlerMs).toBeGreaterThan(0);
+      expect(stats.maxHandlerMs).toBeGreaterThan(0);
+      expect(stats.lastTickAt).toBeGreaterThan(0);
+      expect(stats.errors).toBe(0);
+    });
+
+    it("tracks errors", async () => {
+      const onError = vi.fn();
+      clock = createIntervalClock({ intervalMs: 30, onError });
+
+      clock.start(() => {
+        throw new Error("boom");
+      });
+
+      await sleep(100);
+      clock.stop();
+
+      const stats = clock.stats();
+      expect(stats.errors).toBeGreaterThanOrEqual(1);
+      expect(onError).toHaveBeenCalled();
+    });
+  });
+
+  describe("now()", () => {
+    it("returns Date.now()", () => {
+      clock = createIntervalClock({ intervalMs: 100 });
+      const before = Date.now();
+      const now = clock.now();
+      const after = Date.now();
+      expect(now).toBeGreaterThanOrEqual(before);
+      expect(now).toBeLessThanOrEqual(after);
+    });
+  });
+
+  describe("seq", () => {
+    it("starts at 0 before any ticks", () => {
+      clock = createIntervalClock({ intervalMs: 100 });
+      expect(clock.seq).toBe(0);
+    });
+
+    it("increments with each tick", async () => {
+      clock = createIntervalClock({ intervalMs: 30 });
+      clock.start(() => {});
+      await sleep(100);
+      clock.stop();
+      expect(clock.seq).toBeGreaterThanOrEqual(2);
+    });
+  });
+});
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/src/clock/interval.ts
+++ b/src/clock/interval.ts
@@ -1,0 +1,246 @@
+import type {
+  Clock,
+  IntervalClockOptions,
+  Tick,
+  TickHandler,
+  TickStats,
+  BackpressurePolicy,
+} from "./types.js";
+
+/** Create an interval-based clock using chained setTimeout (never setInterval). */
+export function createIntervalClock(options: IntervalClockOptions): Clock {
+  const {
+    intervalMs,
+    backpressure = "block",
+    maxCatchUpTicks = 3,
+    onDriftWarning,
+    onError,
+  } = options;
+
+  if (intervalMs <= 0) {
+    throw new Error("intervalMs must be positive");
+  }
+
+  let handler: TickHandler | null = null;
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  let _running = false;
+  let _seq = 0;
+  let busy = false;
+
+  // Stats tracking
+  let tickCount = 0;
+  let droppedTicks = 0;
+  let errors = 0;
+  let totalHandlerMs = 0;
+  let totalDriftMs = 0;
+  let lastTickAt = 0;
+  let maxHandlerMs = 0;
+
+  // Drift warning: consecutive high-drift ticks
+  let consecutiveHighDrift = 0;
+  const DRIFT_WARN_RATIO = 0.8;
+  const DRIFT_WARN_COUNT = 5;
+
+  // For fixed-rate modes: track ideal next fire time
+  let nextIdealTime = 0;
+  // Accumulator for adaptive catch-up
+  let accumulator = 0;
+
+  function resetStats(): void {
+    tickCount = 0;
+    droppedTicks = 0;
+    errors = 0;
+    totalHandlerMs = 0;
+    totalDriftMs = 0;
+    lastTickAt = 0;
+    maxHandlerMs = 0;
+    consecutiveHighDrift = 0;
+  }
+
+  async function fireTick(reason: Tick["reason"], drift?: number): Promise<void> {
+    if (!handler) return;
+
+    const tick: Tick = {
+      ts: Date.now(),
+      seq: _seq++,
+      reason,
+      drift,
+    };
+
+    tickCount++;
+    lastTickAt = tick.ts;
+
+    if (drift !== undefined) {
+      totalDriftMs += Math.abs(drift);
+
+      if (Math.abs(drift) > intervalMs * DRIFT_WARN_RATIO) {
+        consecutiveHighDrift++;
+        if (consecutiveHighDrift >= DRIFT_WARN_COUNT && onDriftWarning) {
+          onDriftWarning(drift);
+        }
+      } else {
+        consecutiveHighDrift = 0;
+      }
+    }
+
+    const start = Date.now();
+    try {
+      await handler(tick);
+    } catch (err) {
+      errors++;
+      onError?.(err);
+    }
+    const elapsed = Date.now() - start;
+
+    totalHandlerMs += elapsed;
+    if (elapsed > maxHandlerMs) {
+      maxHandlerMs = elapsed;
+    }
+
+    return;
+  }
+
+  function scheduleBlock(): void {
+    if (!_running) return;
+    timer = setTimeout(async () => {
+      await fireTick("interval", 0);
+      scheduleBlock();
+    }, intervalMs);
+  }
+
+  function scheduleDrop(): void {
+    if (!_running) return;
+
+    const now = Date.now();
+    nextIdealTime = nextIdealTime || now + intervalMs;
+    const delay = Math.max(0, nextIdealTime - now);
+
+    timer = setTimeout(() => {
+      const drift = Date.now() - nextIdealTime;
+      nextIdealTime += intervalMs;
+
+      // Schedule next tick BEFORE handling — fixed-rate, not fixed-delay
+      scheduleDrop();
+
+      if (busy) {
+        droppedTicks++;
+        return;
+      }
+
+      busy = true;
+      const done = async () => {
+        await fireTick("interval", drift);
+        busy = false;
+
+        // Catch-up: fire accumulated ticks up to maxCatchUpTicks
+        let catchUps = 0;
+        while (_running && nextIdealTime <= Date.now() && catchUps < maxCatchUpTicks) {
+          const catchUpDrift = Date.now() - nextIdealTime;
+          nextIdealTime += intervalMs;
+          await fireTick("catchup", catchUpDrift);
+          catchUps++;
+        }
+
+        // Clamp: if still behind, skip ahead (spiral-of-death prevention)
+        if (nextIdealTime < Date.now()) {
+          const skipped = Math.floor((Date.now() - nextIdealTime) / intervalMs);
+          droppedTicks += skipped;
+          nextIdealTime += skipped * intervalMs;
+        }
+      };
+      done();
+    }, delay);
+  }
+
+  function scheduleAdaptive(): void {
+    if (!_running) return;
+
+    const now = Date.now();
+    nextIdealTime = nextIdealTime || now + intervalMs;
+    const delay = Math.max(0, nextIdealTime - now);
+
+    timer = setTimeout(async () => {
+      const actualTime = Date.now();
+      const drift = actualTime - nextIdealTime;
+      accumulator += intervalMs + drift;
+
+      // Fire ticks for accumulated time, clamped at maxCatchUpTicks
+      let fired = 0;
+      while (accumulator >= intervalMs && fired < maxCatchUpTicks + 1) {
+        if (!_running) return;
+        accumulator -= intervalMs;
+        const tickReason = fired === 0 ? "interval" as const : "catchup" as const;
+        await fireTick(tickReason, fired === 0 ? drift : 0);
+        fired++;
+      }
+
+      // Clamp accumulator: spiral-of-death prevention
+      if (accumulator >= intervalMs) {
+        const skipped = Math.floor(accumulator / intervalMs);
+        droppedTicks += skipped;
+        accumulator -= skipped * intervalMs;
+      }
+
+      nextIdealTime = Date.now() + Math.max(0, intervalMs - accumulator);
+      scheduleAdaptive();
+    }, delay);
+  }
+
+  const schedulers: Record<BackpressurePolicy, () => void> = {
+    block: scheduleBlock,
+    drop: scheduleDrop,
+    adaptive: scheduleAdaptive,
+  };
+
+  const clock: Clock = {
+    start(h: TickHandler): void {
+      if (_running) {
+        throw new Error("Clock already running");
+      }
+      handler = h;
+      _running = true;
+      _seq = 0;
+      resetStats();
+      nextIdealTime = 0;
+      accumulator = 0;
+      busy = false;
+      schedulers[backpressure]();
+    },
+
+    stop(): void {
+      _running = false;
+      if (timer !== null) {
+        clearTimeout(timer);
+        timer = null;
+      }
+      handler = null;
+      busy = false;
+    },
+
+    now(): number {
+      return Date.now();
+    },
+
+    stats(): TickStats {
+      return {
+        tickCount,
+        droppedTicks,
+        errors,
+        avgHandlerMs: tickCount > 0 ? totalHandlerMs / tickCount : 0,
+        avgDriftMs: tickCount > 0 ? totalDriftMs / tickCount : 0,
+        lastTickAt,
+        maxHandlerMs,
+      };
+    },
+
+    get running(): boolean {
+      return _running;
+    },
+
+    get seq(): number {
+      return _seq;
+    },
+  };
+
+  return clock;
+}

--- a/src/clock/source.test.ts
+++ b/src/clock/source.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect } from "vitest";
+import { createClockSource } from "./source.js";
+import { createTestClock } from "./test-clock.js";
+import { createSignalBus } from "../bus.js";
+import type { BaseSignal, DefineSignals } from "../types.js";
+import type { Tick } from "./types.js";
+
+type TickSignal = DefineSignals<{
+  "clock.tick": { seq: number; ts: number };
+}>;
+
+function tickToSignal(tick: Tick): TickSignal {
+  return {
+    type: "clock.tick",
+    ts: tick.ts,
+    id: `tick-${tick.seq}`,
+    source: "test-clock",
+    payload: { seq: tick.seq, ts: tick.ts },
+  };
+}
+
+describe("createClockSource", () => {
+  it("has default name 'clock'", () => {
+    const clock = createTestClock(100);
+    const source = createClockSource({ clock, toSignal: tickToSignal });
+    expect(source.name).toBe("clock");
+  });
+
+  it("accepts custom name", () => {
+    const clock = createTestClock(100);
+    const source = createClockSource({
+      clock,
+      toSignal: tickToSignal,
+      name: "heartbeat",
+    });
+    expect(source.name).toBe("heartbeat");
+  });
+
+  it("emits signals on tick", async () => {
+    const clock = createTestClock(100);
+    const source = createClockSource({ clock, toSignal: tickToSignal });
+    const signals: TickSignal[] = [];
+
+    await source.start(async (signal) => {
+      signals.push(signal);
+    });
+
+    await clock.tick(3);
+
+    expect(signals).toHaveLength(3);
+    expect(signals[0]!.type).toBe("clock.tick");
+    expect(signals[0]!.payload.seq).toBe(0);
+    expect(signals[1]!.payload.seq).toBe(1);
+    expect(signals[2]!.payload.seq).toBe(2);
+  });
+
+  it("stops the clock on stop", async () => {
+    const clock = createTestClock(100);
+    const source = createClockSource({ clock, toSignal: tickToSignal });
+
+    await source.start(async () => {});
+    expect(clock.running).toBe(true);
+
+    await source.stop();
+    expect(clock.running).toBe(false);
+  });
+
+  describe("integration: TestClock → ClockSource → SignalBus", () => {
+    it("signals flow through the full pipeline", async () => {
+      const clock = createTestClock(1000);
+      const source = createClockSource({ clock, toSignal: tickToSignal });
+      const bus = createSignalBus<TickSignal>();
+
+      const received: TickSignal[] = [];
+      bus.on("clock.tick", (signal) => {
+        received.push(signal);
+      });
+
+      await source.start((signal) => bus.emit(signal));
+      await clock.tick(5);
+
+      expect(received).toHaveLength(5);
+      expect(received[0]!.type).toBe("clock.tick");
+      expect(received[0]!.payload.seq).toBe(0);
+      expect(received[4]!.payload.seq).toBe(4);
+
+      // Bus stats should reflect the signals
+      const stats = bus.stats();
+      expect(stats.emitted).toBe(5);
+      expect(stats.handled).toBe(5);
+
+      await source.stop();
+    });
+
+    it("works with advanceBy", async () => {
+      const clock = createTestClock(100);
+      const source = createClockSource({ clock, toSignal: tickToSignal });
+      const bus = createSignalBus<TickSignal>();
+
+      const received: TickSignal[] = [];
+      bus.on("clock.tick", (signal) => {
+        received.push(signal);
+      });
+
+      await source.start((signal) => bus.emit(signal));
+      await clock.advanceBy(350); // 3 ticks + 50ms residual
+
+      expect(received).toHaveLength(3);
+
+      await clock.flush(); // Fire the residual
+      expect(received).toHaveLength(4);
+
+      await source.stop();
+    });
+  });
+});

--- a/src/clock/source.ts
+++ b/src/clock/source.ts
@@ -1,0 +1,39 @@
+import type { BaseSignal, Source } from "../types.js";
+import type { Clock, Tick } from "./types.js";
+
+/** Options for creating a ClockSource adapter. */
+export interface ClockSourceOptions<S extends BaseSignal> {
+  /** The clock to adapt. */
+  clock: Clock;
+  /** Convert a tick into a signal. Same pattern as cron/file-watcher sources. */
+  toSignal: (tick: Tick) => S;
+  /** Source name for debugging. Default: "clock". */
+  name?: string;
+}
+
+/**
+ * Adapt any Clock into a Source<S>.
+ *
+ * Follows the same `toSignal` pattern from cron and file-watcher sources.
+ * The clock's tick handler emits signals via the provided emit function.
+ */
+export function createClockSource<S extends BaseSignal>(
+  options: ClockSourceOptions<S>,
+): Source<S> {
+  const { clock, toSignal, name = "clock" } = options;
+
+  return {
+    name,
+
+    async start(emit: (signal: S) => Promise<void>): Promise<void> {
+      clock.start(async (tick) => {
+        const signal = toSignal(tick);
+        await emit(signal);
+      });
+    },
+
+    async stop(): Promise<void> {
+      clock.stop();
+    },
+  };
+}

--- a/src/clock/test-clock.test.ts
+++ b/src/clock/test-clock.test.ts
@@ -1,0 +1,199 @@
+import { describe, it, expect } from "vitest";
+import { createTestClock } from "./test-clock.js";
+import type { Tick } from "./types.js";
+
+describe("createTestClock", () => {
+  it("starts with seq 0 and virtual time 0", () => {
+    const clock = createTestClock(100);
+    expect(clock.seq).toBe(0);
+    expect(clock.now()).toBe(0);
+    expect(clock.running).toBe(false);
+  });
+
+  it("throws if started twice", () => {
+    const clock = createTestClock(100);
+    clock.start(() => {});
+    expect(() => clock.start(() => {})).toThrow("Clock already running");
+  });
+
+  it("throws tick/advanceBy/flush if not running", async () => {
+    const clock = createTestClock(100);
+    await expect(clock.tick()).rejects.toThrow("Clock not running");
+    await expect(clock.advanceBy(100)).rejects.toThrow("Clock not running");
+    await expect(clock.flush()).rejects.toThrow("Clock not running");
+  });
+
+  describe("tick()", () => {
+    it("fires one tick with correct seq and ts", async () => {
+      const clock = createTestClock(1000);
+      const ticks: Tick[] = [];
+      clock.start((tick) => { ticks.push(tick); });
+
+      await clock.tick();
+
+      expect(ticks).toHaveLength(1);
+      expect(ticks[0]!.seq).toBe(0);
+      expect(ticks[0]!.ts).toBe(1000);
+      expect(ticks[0]!.reason).toBe("manual");
+      expect(clock.now()).toBe(1000);
+      expect(clock.seq).toBe(1);
+    });
+
+    it("fires N ticks sequentially", async () => {
+      const clock = createTestClock(500);
+      const ticks: Tick[] = [];
+      clock.start((tick) => { ticks.push(tick); });
+
+      await clock.tick(3);
+
+      expect(ticks).toHaveLength(3);
+      expect(ticks[0]!.seq).toBe(0);
+      expect(ticks[0]!.ts).toBe(500);
+      expect(ticks[1]!.seq).toBe(1);
+      expect(ticks[1]!.ts).toBe(1000);
+      expect(ticks[2]!.seq).toBe(2);
+      expect(ticks[2]!.ts).toBe(1500);
+      expect(clock.now()).toBe(1500);
+    });
+
+    it("rethrows handler errors", async () => {
+      const clock = createTestClock(100);
+      clock.start(() => { throw new Error("boom"); });
+
+      await expect(clock.tick()).rejects.toThrow("boom");
+      expect(clock.stats().errors).toBe(1);
+    });
+  });
+
+  describe("advanceBy()", () => {
+    it("fires correct number of ticks for exact multiple", async () => {
+      const clock = createTestClock(100);
+      const ticks: Tick[] = [];
+      clock.start((tick) => { ticks.push(tick); });
+
+      await clock.advanceBy(300);
+
+      expect(ticks).toHaveLength(3);
+      expect(clock.now()).toBe(300);
+    });
+
+    it("keeps residual in accumulator", async () => {
+      const clock = createTestClock(100);
+      const ticks: Tick[] = [];
+      clock.start((tick) => { ticks.push(tick); });
+
+      await clock.advanceBy(250);
+
+      expect(ticks).toHaveLength(2);
+      expect(clock.now()).toBe(200);
+      expect(clock.pendingTicks).toBe(0);
+      // 50ms residual in accumulator — not enough for a tick
+    });
+
+    it("accumulator carries across calls", async () => {
+      const clock = createTestClock(100);
+      const ticks: Tick[] = [];
+      clock.start((tick) => { ticks.push(tick); });
+
+      await clock.advanceBy(150); // 1 tick, 50ms residual
+      expect(ticks).toHaveLength(1);
+
+      await clock.advanceBy(60); // 50+60=110ms → 1 tick, 10ms residual
+      expect(ticks).toHaveLength(2);
+    });
+
+    it("fires zero ticks for sub-interval advance", async () => {
+      const clock = createTestClock(1000);
+      const ticks: Tick[] = [];
+      clock.start((tick) => { ticks.push(tick); });
+
+      await clock.advanceBy(500);
+
+      expect(ticks).toHaveLength(0);
+      expect(clock.now()).toBe(0);
+    });
+  });
+
+  describe("flush()", () => {
+    it("fires tick for remaining accumulator", async () => {
+      const clock = createTestClock(100);
+      const ticks: Tick[] = [];
+      clock.start((tick) => { ticks.push(tick); });
+
+      await clock.advanceBy(150); // 1 tick, 50ms residual
+      expect(ticks).toHaveLength(1);
+
+      await clock.flush(); // Fires for the 50ms residual
+      expect(ticks).toHaveLength(2);
+      expect(clock.now()).toBe(150);
+    });
+
+    it("no-ops when accumulator is empty", async () => {
+      const clock = createTestClock(100);
+      const ticks: Tick[] = [];
+      clock.start((tick) => { ticks.push(tick); });
+
+      await clock.advanceBy(200); // Exact, no residual
+      await clock.flush();
+
+      expect(ticks).toHaveLength(2);
+    });
+  });
+
+  describe("reset()", () => {
+    it("resets to t=0, seq=0", async () => {
+      const clock = createTestClock(100);
+      clock.start(() => {});
+      await clock.tick(5);
+
+      expect(clock.now()).toBe(500);
+      expect(clock.seq).toBe(5);
+
+      clock.reset();
+      expect(clock.now()).toBe(0);
+      expect(clock.seq).toBe(0);
+      expect(clock.stats().tickCount).toBe(0);
+    });
+
+    it("clears accumulator", async () => {
+      const clock = createTestClock(100);
+      clock.start(() => {});
+      await clock.advanceBy(150);
+
+      clock.reset();
+      expect(clock.pendingTicks).toBe(0);
+    });
+  });
+
+  describe("stats", () => {
+    it("tracks tick count", async () => {
+      const clock = createTestClock(100);
+      clock.start(() => {});
+      await clock.tick(3);
+
+      const stats = clock.stats();
+      expect(stats.tickCount).toBe(3);
+      expect(stats.droppedTicks).toBe(0);
+      expect(stats.errors).toBe(0);
+      expect(stats.lastTickAt).toBe(300);
+    });
+  });
+
+  describe("async handlers", () => {
+    it("awaits async handlers before continuing", async () => {
+      const clock = createTestClock(100);
+      const order: string[] = [];
+
+      clock.start(async () => {
+        order.push("handler-start");
+        await Promise.resolve();
+        order.push("handler-end");
+      });
+
+      await clock.tick();
+      order.push("after-tick");
+
+      expect(order).toEqual(["handler-start", "handler-end", "after-tick"]);
+    });
+  });
+});

--- a/src/clock/test-clock.ts
+++ b/src/clock/test-clock.ts
@@ -1,0 +1,162 @@
+import type { Clock, Tick, TickHandler, TickStats } from "./types.js";
+
+/** Extended Clock with manual tick control for deterministic testing. */
+export interface TestClock extends Clock {
+  /** Fire N ticks (default: 1). Awaits handler for each. */
+  tick(count?: number): Promise<void>;
+  /** Advance virtual time by ms, firing due ticks. Residual stays in accumulator. */
+  advanceBy(ms: number): Promise<void>;
+  /** Execute all pending ticks. */
+  flush(): Promise<void>;
+  /** Reset to t=0, seq=0. */
+  reset(): void;
+  /** Number of ticks pending in accumulator. */
+  readonly pendingTicks: number;
+}
+
+/**
+ * Create a deterministic test clock. No real timers.
+ *
+ * - `now()` returns virtual time, never `Date.now()`
+ * - `start()` registers handler but does NOT auto-tick
+ * - `tick()` fires handler synchronously with correct ts/seq
+ * - `advanceBy()` computes tick count, fires them, residual in accumulator
+ */
+export function createTestClock(intervalMs = 1000): TestClock {
+  let handler: TickHandler | null = null;
+  let _running = false;
+  let _seq = 0;
+  let virtualTime = 0;
+  let accumulator = 0;
+
+  // Stats
+  let tickCount = 0;
+  let errors = 0;
+  let totalHandlerMs = 0;
+  let lastTickAt = 0;
+  let maxHandlerMs = 0;
+
+  function resetStats(): void {
+    tickCount = 0;
+    errors = 0;
+    totalHandlerMs = 0;
+    lastTickAt = 0;
+    maxHandlerMs = 0;
+  }
+
+  async function fireSingleTick(reason: Tick["reason"] = "manual"): Promise<void> {
+    if (!handler) return;
+
+    const tick: Tick = {
+      ts: virtualTime,
+      seq: _seq++,
+      reason,
+    };
+
+    tickCount++;
+    lastTickAt = virtualTime;
+
+    const start = performance.now();
+    try {
+      await handler(tick);
+    } catch (err) {
+      errors++;
+      // In test clock, rethrow so tests can catch errors
+      throw err;
+    }
+    const elapsed = performance.now() - start;
+    totalHandlerMs += elapsed;
+    if (elapsed > maxHandlerMs) {
+      maxHandlerMs = elapsed;
+    }
+  }
+
+  const clock: TestClock = {
+    start(h: TickHandler): void {
+      if (_running) {
+        throw new Error("Clock already running");
+      }
+      handler = h;
+      _running = true;
+    },
+
+    stop(): void {
+      _running = false;
+      handler = null;
+      accumulator = 0;
+    },
+
+    now(): number {
+      return virtualTime;
+    },
+
+    stats(): TickStats {
+      return {
+        tickCount,
+        droppedTicks: 0, // Test clock never drops
+        errors,
+        avgHandlerMs: tickCount > 0 ? totalHandlerMs / tickCount : 0,
+        avgDriftMs: 0, // No drift in virtual time
+        lastTickAt,
+        maxHandlerMs,
+      };
+    },
+
+    get running(): boolean {
+      return _running;
+    },
+
+    get seq(): number {
+      return _seq;
+    },
+
+    async tick(count = 1): Promise<void> {
+      if (!_running) {
+        throw new Error("Clock not running");
+      }
+      for (let i = 0; i < count; i++) {
+        virtualTime += intervalMs;
+        await fireSingleTick("manual");
+      }
+    },
+
+    async advanceBy(ms: number): Promise<void> {
+      if (!_running) {
+        throw new Error("Clock not running");
+      }
+      accumulator += ms;
+      const ticksToFire = Math.floor(accumulator / intervalMs);
+      accumulator -= ticksToFire * intervalMs;
+
+      for (let i = 0; i < ticksToFire; i++) {
+        virtualTime += intervalMs;
+        await fireSingleTick("manual");
+      }
+    },
+
+    async flush(): Promise<void> {
+      if (!_running) {
+        throw new Error("Clock not running");
+      }
+      if (accumulator > 0) {
+        // Fire one more tick for any remaining accumulator
+        virtualTime += accumulator;
+        accumulator = 0;
+        await fireSingleTick("manual");
+      }
+    },
+
+    reset(): void {
+      virtualTime = 0;
+      _seq = 0;
+      accumulator = 0;
+      resetStats();
+    },
+
+    get pendingTicks(): number {
+      return Math.floor(accumulator / intervalMs);
+    },
+  };
+
+  return clock;
+}

--- a/src/clock/types.ts
+++ b/src/clock/types.ts
@@ -1,0 +1,79 @@
+/**
+ * Clock primitives for Cadence.
+ *
+ * A Clock is a lower-level timing primitive than a Source.
+ * Use createClockSource to adapt a Clock into a Source.
+ */
+
+/** A single tick emitted by a Clock. */
+export interface Tick {
+  /** Unix timestamp (ms) when this tick fired */
+  ts: number;
+  /** Monotonic counter, 0-based */
+  seq: number;
+  /** Why this tick fired */
+  reason: "interval" | "bridge" | "manual" | "catchup";
+  /** Milliseconds from ideal fire time (only for interval clocks) */
+  drift?: number;
+}
+
+/** Handler invoked on each tick. */
+export type TickHandler = (tick: Tick) => void | Promise<void>;
+
+/**
+ * Backpressure policy for interval clocks.
+ *
+ * - `"block"` — Fixed-delay. Next tick scheduled after handler completes + intervalMs.
+ *   Prevents spiral of death by construction. **Default.**
+ * - `"drop"` — Fixed-rate. Skip tick if handler is still busy. Dropped ticks counted in stats.
+ * - `"adaptive"` — Fixed-rate with self-correction: nextDelay = max(0, intervalMs - elapsed).
+ */
+export type BackpressurePolicy = "block" | "drop" | "adaptive";
+
+/** Observable tick statistics. */
+export interface TickStats {
+  /** Total ticks fired */
+  tickCount: number;
+  /** Ticks skipped due to backpressure (drop policy) */
+  droppedTicks: number;
+  /** Handler errors caught */
+  errors: number;
+  /** Rolling average handler duration (ms) */
+  avgHandlerMs: number;
+  /** Rolling average drift from ideal fire time (ms) */
+  avgDriftMs: number;
+  /** Timestamp of most recent tick */
+  lastTickAt: number;
+  /** Maximum handler duration observed (ms) */
+  maxHandlerMs: number;
+}
+
+/** Core clock interface. */
+export interface Clock {
+  /** Register handler and start ticking. */
+  start(handler: TickHandler): void;
+  /** Stop ticking. Idempotent. */
+  stop(): void;
+  /** Current time in ms. Testing seam — real clocks return Date.now(). */
+  now(): number;
+  /** Current tick statistics. */
+  stats(): TickStats;
+  /** Whether the clock is currently running. */
+  readonly running: boolean;
+  /** Current sequence number. */
+  readonly seq: number;
+}
+
+/** Options for createIntervalClock. */
+export interface IntervalClockOptions {
+  /** Interval between ticks in milliseconds. */
+  intervalMs: number;
+  /** Backpressure strategy. Default: "block". */
+  backpressure?: BackpressurePolicy;
+  /** Max catch-up ticks per cycle for drop/adaptive. Default: 3. */
+  maxCatchUpTicks?: number;
+  /** Called when drift exceeds 80% of interval for 5+ consecutive ticks. */
+  onDriftWarning?: (driftMs: number) => void;
+  /** Called when handler throws. */
+  onError?: (error: unknown) => void;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,3 +38,15 @@ export type { FileEvent, FileEventType, FileWatcherOptions } from "./sources/fil
 
 export { createCronSource, getNextRun, isValidCronExpr } from "./sources/cron.js";
 export type { CronJob, CronSourceOptions } from "./sources/cron.js";
+
+// Clock primitives
+export type {
+  Tick,
+  TickHandler,
+  BackpressurePolicy,
+  TickStats,
+  Clock,
+  IntervalClockOptions,
+} from "./clock/types.js";
+
+export { createIntervalClock } from "./clock/interval.js";

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,3 +50,7 @@ export type {
 } from "./clock/types.js";
 
 export { createIntervalClock } from "./clock/interval.js";
+export { createTestClock } from "./clock/test-clock.js";
+export type { TestClock } from "./clock/test-clock.js";
+export { createBridgeClock } from "./clock/bridge.js";
+export type { BridgeClock } from "./clock/bridge.js";

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,3 +35,6 @@ export { createSequentialExecutor } from "./executor/sequential.js";
 // Sources
 export { createFileWatcherSource } from "./sources/file-watcher.js";
 export type { FileEvent, FileEventType, FileWatcherOptions } from "./sources/file-watcher.js";
+
+export { createCronSource, getNextRun, isValidCronExpr } from "./sources/cron.js";
+export type { CronJob, CronSourceOptions } from "./sources/cron.js";

--- a/src/index.ts
+++ b/src/index.ts
@@ -54,3 +54,5 @@ export { createTestClock } from "./clock/test-clock.js";
 export type { TestClock } from "./clock/test-clock.js";
 export { createBridgeClock } from "./clock/bridge.js";
 export type { BridgeClock } from "./clock/bridge.js";
+export { createClockSource } from "./clock/source.js";
+export type { ClockSourceOptions } from "./clock/source.js";

--- a/src/sources/cron.test.ts
+++ b/src/sources/cron.test.ts
@@ -1,0 +1,183 @@
+/**
+ * Tests for the cron source.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { createCronSource, getNextRun, isValidCronExpr } from "./cron.js";
+import type { BaseSignal } from "../types.js";
+
+interface TestSignal extends BaseSignal {
+  type: "test.cron.fired";
+  payload: { jobId: string; jobName: string; firedAt: number };
+}
+
+describe("createCronSource", () => {
+  it("creates a source with name 'cron'", () => {
+    const source = createCronSource<TestSignal>({
+      jobs: [],
+      toSignal: (job, firedAt) => ({
+        type: "test.cron.fired",
+        id: "test-id",
+        ts: firedAt,
+        payload: { jobId: job.id, jobName: job.name, firedAt },
+      }),
+    });
+
+    expect(source.name).toBe("cron");
+  });
+
+  it("calls onError callback for invalid cron expressions", async () => {
+    const errors: { jobId: string; error: Error }[] = [];
+
+    const source = createCronSource<TestSignal>({
+      jobs: [{ id: "invalid", name: "Invalid Job", expr: "not a cron expression" }],
+      toSignal: (job, firedAt) => ({
+        type: "test.cron.fired",
+        id: "signal-id",
+        ts: firedAt,
+        payload: { jobId: job.id, jobName: job.name, firedAt },
+      }),
+      onError: (job, error) => {
+        errors.push({ jobId: job.id, error });
+      },
+    });
+
+    await source.start(() => Promise.resolve());
+    await source.stop();
+
+    expect(errors.length).toBe(1);
+    expect(errors[0].jobId).toBe("invalid");
+  });
+
+  it("does not schedule disabled jobs", async () => {
+    const scheduledJobs: string[] = [];
+
+    const source = createCronSource<TestSignal>({
+      jobs: [
+        { id: "enabled", name: "Enabled Job", expr: "0 8 * * *" },
+        { id: "disabled", name: "Disabled Job", expr: "0 8 * * *", enabled: false },
+      ],
+      toSignal: (job, firedAt) => ({
+        type: "test.cron.fired",
+        id: `signal-${job.id}`,
+        ts: firedAt,
+        payload: { jobId: job.id, jobName: job.name, firedAt },
+      }),
+      onFire: (job) => {
+        scheduledJobs.push(job.id);
+      },
+    });
+
+    // Start and immediately stop - we're just testing that disabled jobs aren't scheduled
+    await source.start(() => Promise.resolve());
+
+    // The croner library schedules jobs synchronously on start
+    // Disabled jobs should be skipped entirely (no cron instance created)
+    // We can verify by checking that no errors occur and stop works cleanly
+    await source.stop();
+
+    // No errors should occur
+    expect(true).toBe(true);
+  });
+
+  it("can start and stop cleanly", async () => {
+    const source = createCronSource<TestSignal>({
+      jobs: [
+        { id: "job1", name: "Job 1", expr: "0 8 * * *" },
+        { id: "job2", name: "Job 2", expr: "0 18 * * *" },
+      ],
+      toSignal: (job, firedAt) => ({
+        type: "test.cron.fired",
+        id: "signal-id",
+        ts: firedAt,
+        payload: { jobId: job.id, jobName: job.name, firedAt },
+      }),
+    });
+
+    // Should not throw
+    await source.start(() => Promise.resolve());
+    await source.stop();
+
+    // Can restart after stop
+    await source.start(() => Promise.resolve());
+    await source.stop();
+  });
+
+  it("toSignal receives correct job info", async () => {
+    const receivedJobs: Array<{ id: string; name: string; expr: string }> = [];
+
+    // Use a mock that captures the toSignal calls
+    const source = createCronSource<TestSignal>({
+      jobs: [{ id: "test-job", name: "Test Job", expr: "* * * * * *" }], // every second
+      toSignal: (job, firedAt) => {
+        receivedJobs.push({ id: job.id, name: job.name, expr: job.expr });
+        return {
+          type: "test.cron.fired",
+          id: "signal-id",
+          ts: firedAt,
+          payload: { jobId: job.id, jobName: job.name, firedAt },
+        };
+      },
+    });
+
+    await source.start(() => Promise.resolve());
+
+    // Wait for one tick (croner uses seconds for 6-part expressions)
+    await new Promise((resolve) => setTimeout(resolve, 1100));
+
+    await source.stop();
+
+    // Should have received at least one call
+    expect(receivedJobs.length).toBeGreaterThanOrEqual(1);
+    expect(receivedJobs[0]).toEqual({
+      id: "test-job",
+      name: "Test Job",
+      expr: "* * * * * *",
+    });
+  }, 3000);
+});
+
+describe("getNextRun", () => {
+  it("returns a Date for valid cron expressions", () => {
+    const next = getNextRun("0 8 * * *"); // 8am daily
+    expect(next).toBeInstanceOf(Date);
+  });
+
+  it("returns null for invalid cron expressions", () => {
+    const next = getNextRun("invalid cron");
+    expect(next).toBeNull();
+  });
+
+  it("respects timezone parameter", () => {
+    const nextNY = getNextRun("0 8 * * *", "America/New_York");
+    const nextLA = getNextRun("0 8 * * *", "America/Los_Angeles");
+
+    // Both should be valid dates
+    expect(nextNY).toBeInstanceOf(Date);
+    expect(nextLA).toBeInstanceOf(Date);
+
+    // LA is 3 hours behind NY, so 8am LA is later than 8am NY
+    if (nextNY && nextLA) {
+      // The difference should be related to timezone offset
+      // We just verify both are valid - exact timing depends on current time
+      expect(nextNY.getTime()).not.toBe(nextLA.getTime());
+    }
+  });
+});
+
+describe("isValidCronExpr", () => {
+  it("returns true for valid cron expressions", () => {
+    expect(isValidCronExpr("* * * * *")).toBe(true); // every minute
+    expect(isValidCronExpr("0 8 * * *")).toBe(true); // 8am daily
+    expect(isValidCronExpr("0 0 1 * *")).toBe(true); // first of month
+    expect(isValidCronExpr("*/5 * * * *")).toBe(true); // every 5 minutes
+    expect(isValidCronExpr("0 8,18 * * 1-5")).toBe(true); // 8am and 6pm weekdays
+  });
+
+  it("returns false for invalid cron expressions", () => {
+    expect(isValidCronExpr("invalid")).toBe(false);
+    expect(isValidCronExpr("not a cron")).toBe(false);
+    expect(isValidCronExpr("")).toBe(false);
+    expect(isValidCronExpr("60 * * * *")).toBe(false); // 60 is invalid minute
+  });
+});

--- a/src/sources/cron.ts
+++ b/src/sources/cron.ts
@@ -1,0 +1,134 @@
+/**
+ * Cron Source — emits signals on a schedule.
+ *
+ * Portable implementation using croner (lightweight, no native deps).
+ * Can be swapped with platform-specific implementations.
+ */
+
+import { Cron } from "croner";
+import type { BaseSignal, Source } from "../types.js";
+
+export interface CronJob {
+  /** Unique job identifier */
+  id: string;
+  /** Human-readable name */
+  name: string;
+  /** Cron expression (e.g., "0 8 * * *" = 8am daily) */
+  expr: string;
+  /** Timezone (e.g., "America/New_York") */
+  tz?: string;
+  /** Whether job is enabled (default: true) */
+  enabled?: boolean;
+}
+
+export interface CronSourceOptions<S extends BaseSignal> {
+  /** Jobs to schedule */
+  jobs: CronJob[];
+
+  /**
+   * Factory to create signal when job fires.
+   * Receives job info and returns the signal to emit.
+   */
+  toSignal: (job: CronJob, firedAt: number) => S;
+
+  /** Called when a job fires (for logging/debugging) */
+  onFire?: (job: CronJob) => void;
+
+  /** Called on cron parse error */
+  onError?: (job: CronJob, error: Error) => void;
+}
+
+interface ActiveJob {
+  job: CronJob;
+  cron: Cron;
+}
+
+/**
+ * Create a cron source that emits signals on schedule.
+ *
+ * @example
+ * ```typescript
+ * const source = createCronSource<MySignals>({
+ *   jobs: [
+ *     { id: "morning", name: "Morning Check", expr: "0 8 * * *", tz: "America/New_York" },
+ *     { id: "evening", name: "Evening Digest", expr: "0 18 * * *", tz: "America/New_York" },
+ *   ],
+ *   toSignal: (job, firedAt) => ({
+ *     type: "cron.fired",
+ *     id: crypto.randomUUID(),
+ *     ts: firedAt,
+ *     payload: { jobId: job.id, jobName: job.name, expr: job.expr, firedAt },
+ *   }),
+ * });
+ *
+ * await source.start((signal) => bus.emit(signal));
+ * ```
+ */
+export function createCronSource<S extends BaseSignal>(
+  options: CronSourceOptions<S>,
+): Source<S> {
+  const activeJobs: ActiveJob[] = [];
+
+  return {
+    name: "cron",
+
+    async start(emit) {
+      for (const job of options.jobs) {
+        // Skip disabled jobs
+        if (job.enabled === false) {
+          continue;
+        }
+
+        try {
+          const cron = new Cron(job.expr, { timezone: job.tz }, async () => {
+            const firedAt = Date.now();
+            options.onFire?.(job);
+
+            const signal = options.toSignal(job, firedAt);
+            await emit(signal);
+          });
+
+          activeJobs.push({ job, cron });
+        } catch (err) {
+          const error = err instanceof Error ? err : new Error(String(err));
+          options.onError?.(job, error);
+        }
+      }
+    },
+
+    async stop() {
+      for (const { cron } of activeJobs) {
+        cron.stop();
+      }
+      activeJobs.length = 0;
+    },
+  };
+}
+
+/**
+ * Get next run time for a cron expression.
+ * Useful for displaying "next run at" in UI.
+ */
+export function getNextRun(expr: string, tz?: string): Date | null {
+  try {
+    const cron = new Cron(expr, { timezone: tz });
+    const next = cron.nextRun();
+    cron.stop();
+    return next;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Validate a cron expression.
+ */
+export function isValidCronExpr(expr: string): boolean {
+  try {
+    const cron = new Cron(expr);
+    cron.stop();
+    return true;
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary
- `createClockSource` wraps any `Clock` into a `Source<S>` using the same `toSignal` pattern from cron and file-watcher sources
- Integration tested: `TestClock → ClockSource → SignalBus → handler` verifies full pipeline

## Test plan
- [x] Default name is "clock"
- [x] Custom name accepted
- [x] Emits signals on each tick
- [x] Stop stops the underlying clock
- [x] Integration: TestClock → ClockSource → SignalBus — signals flow through full pipeline
- [x] Integration: advanceBy + flush work through pipeline

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)