### PR TITLE
docs: add MkDocs documentation site

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,50 @@
+name: Deploy docs
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'docs/**'
+      - 'mkdocs.yml'
+      - 'requirements.txt'
+      - '.github/workflows/docs.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+      - name: Build docs
+        run: mkdocs build --strict
+
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ coverage/
 # Environment
 .env
 .env.local
+
+# MkDocs build output
+site/

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,0 +1,27 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.0] - 2026-02-03
+
+### Added
+
+- Core signal bus with typed pub/sub (`createSignalBus`)
+- `DefineSignals<M>` helper for type-safe signal definitions
+- Pluggable architecture:
+  - `Transport` interface (default: `MemoryTransport`)
+  - `SignalStore` interface (default: `NoopStore`)
+  - `HandlerExecutor` interface (default: `SequentialExecutor`)
+- Middleware support (`bus.use()`)
+- Signal replay from store (`bus.replay()`)
+- File watcher source (`createFileWatcherSource`)
+- Cron source (`createCronSource`) with timezone support
+- Clock system:
+  - `IntervalClock` with block/drop/adaptive backpressure
+  - `TestClock` for deterministic testing
+  - `BridgeClock` for external event adaptation
+  - `ClockSource` adapter (Clock → Source)
+- Full test suite (97% coverage)

--- a/docs/getting-started/concepts.md
+++ b/docs/getting-started/concepts.md
@@ -1,0 +1,128 @@
+# Core Concepts
+
+## Architecture Overview
+
+```mermaid
+graph TD
+    S1[FileWatcherSource] -->|emit| B[SignalBus]
+    S2[CronSource] -->|emit| B
+    S3[ClockSource] -->|emit| B
+
+    B --> MW[Middleware Pipeline]
+    MW --> H1[Type Handlers]
+    MW --> H2[Any Handlers]
+
+    B --> T[Transport]
+    B --> ST[Store]
+    B --> E[Executor]
+
+    T -.->|default| MT[MemoryTransport]
+    ST -.->|default| NS[NoopStore]
+    E -.->|default| SE[SequentialExecutor]
+```
+
+Cadence has five core abstractions. Each is a pluggable interface with a sensible default.
+
+## Signal
+
+A signal is a typed event with a standard shape:
+
+```typescript
+interface BaseSignal<T extends string = string, P = unknown> {
+  type: T;        // Signal type identifier
+  ts: number;     // Unix timestamp (ms)
+  id: string;     // Unique ID
+  source?: string; // Origin identifier
+  payload: P;     // Signal-specific data
+}
+```
+
+You define your own signal types using `DefineSignals`:
+
+```typescript
+type MySignals = DefineSignals<{
+  "file.changed": { path: string };
+  "cron.fired": { jobId: string };
+}>;
+// Result: BaseSignal<"file.changed", { path: string }>
+//       | BaseSignal<"cron.fired", { jobId: string }>
+```
+
+## Bus
+
+The signal bus routes signals to handlers. It coordinates transport, store, and executor:
+
+```typescript
+interface SignalBus<S extends BaseSignal> {
+  emit(signal: S): Promise<void>;
+  on<T extends S["type"]>(type: T, handler: SignalHandler<S, T>): () => void;
+  onAny(handler: AnySignalHandler<S>): () => void;
+  use(middleware: Middleware<S>): void;
+  clear(): void;
+  stats(): BusStats;
+  replay(): Promise<number>;
+}
+```
+
+When you `emit()`, the bus saves to the store, dispatches through the transport, runs the middleware chain, then executes matching handlers via the executor.
+
+## Source
+
+Sources produce signals from external events. Every source follows the same pattern:
+
+```typescript
+interface Source<S extends BaseSignal> {
+  name: string;
+  start(emit: (signal: S) => Promise<void>): Promise<void>;
+  stop(): Promise<void>;
+}
+```
+
+Built-in sources: `createFileWatcherSource` (file changes) and `createCronSource` (schedules). The `createClockSource` adapter converts any Clock into a Source.
+
+## Clock
+
+Clocks are lower-level timing primitives. They tick at a rate and call a handler:
+
+```typescript
+interface Clock {
+  start(handler: TickHandler): void;
+  stop(): void;
+  now(): number;
+  stats(): TickStats;
+  readonly running: boolean;
+  readonly seq: number;
+}
+```
+
+Three implementations:
+
+- **IntervalClock** — Production timer with backpressure policies
+- **TestClock** — Deterministic virtual time for testing
+- **BridgeClock** — Adapts external heartbeats into ticks
+
+## Pluggable Layers
+
+Every layer has an interface and a default implementation:
+
+| Layer | Interface | Default | Purpose |
+|-------|-----------|---------|---------|
+| **Transport** | `Transport<S>` | `MemoryTransport` | How signals move between emitter and subscribers |
+| **Store** | `SignalStore<S>` | `NoopStore` | Persistence for durability and replay |
+| **Executor** | `HandlerExecutor<S>` | `SequentialExecutor` | Controls handler concurrency |
+
+You can swap any layer independently:
+
+```typescript
+const bus = createSignalBus<MySignals>({
+  transport: createMemoryTransport(), // or your Redis transport
+  store: createNoopStore(),           // or your SQLite store
+  executor: createSequentialExecutor(), // or your concurrent executor
+});
+```
+
+## Design Philosophy
+
+- **Domain-agnostic** — Cadence is infrastructure. It has no concept of files, cron, or AI. Consumers define signal types and sources that make sense for their domain.
+- **Build for the sophisticated case, implement simple** — Every interface supports advanced use cases (distributed transport, durable store, concurrent execution). The defaults are the simplest possible implementation.
+- **Pluggable, not configurable** — Instead of options flags, swap entire implementations. This keeps interfaces small and behavior predictable.

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -1,0 +1,55 @@
+# Installation
+
+## Prerequisites
+
+- Node.js 22 or later
+- TypeScript 5.7+ (for strict mode compatibility)
+
+## Install
+
+```bash
+# pnpm (recommended)
+pnpm add @peleke.s/cadence
+
+# npm
+npm install @peleke.s/cadence
+
+# yarn
+yarn add @peleke.s/cadence
+```
+
+## TypeScript Configuration
+
+Cadence is written in strict TypeScript with ESM. Your `tsconfig.json` should include:
+
+```json
+{
+  "compilerOptions": {
+    "strict": true,
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "target": "ES2022"
+  }
+}
+```
+
+## Verify Installation
+
+```typescript
+import { createSignalBus } from "@peleke.s/cadence";
+
+const bus = createSignalBus();
+console.log(bus.stats());
+// { emitted: 0, handled: 0, errors: 0, handlers: 0, anyHandlers: 0, middleware: 0 }
+```
+
+## Dependencies
+
+Cadence has two production dependencies:
+
+| Package | Purpose |
+|---------|---------|
+| [chokidar](https://github.com/paulmillr/chokidar) | File system watching for `createFileWatcherSource` |
+| [croner](https://github.com/hexagon/croner) | Cron expression parsing for `createCronSource` |
+
+Both are lightweight with no native add-ons.

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -1,0 +1,98 @@
+# Quick Start
+
+Build a file-watching signal pipeline in under 5 minutes.
+
+## Step 1: Define your signals
+
+Every Cadence project starts by defining signal types. Use `DefineSignals` to create a type-safe union from a simple map:
+
+```typescript
+import { type DefineSignals } from "@peleke.s/cadence";
+
+type MySignals = DefineSignals<{
+  "file.changed": { path: string; event: "add" | "change" | "unlink" };
+  "task.found": { file: string; line: number; text: string };
+}>;
+```
+
+Each key becomes a signal `type`, each value becomes the `payload` shape. TypeScript enforces this everywhere.
+
+## Step 2: Create a bus and subscribe
+
+```typescript
+import { createSignalBus } from "@peleke.s/cadence";
+
+const bus = createSignalBus<MySignals>();
+
+// Type-specific handler — only receives "file.changed" signals
+bus.on("file.changed", async (signal) => {
+  console.log(`[${signal.payload.event}] ${signal.payload.path}`);
+});
+
+// Any-handler — receives all signals
+bus.onAny(async (signal) => {
+  console.log(`Signal: ${signal.type} at ${new Date(signal.ts).toISOString()}`);
+});
+```
+
+## Step 3: Create a source and connect it
+
+Sources produce signals from external events. Connect them to the bus with `start()`:
+
+```typescript
+import { createFileWatcherSource } from "@peleke.s/cadence";
+
+const watcher = createFileWatcherSource<MySignals>({
+  paths: ["./notes"],
+  toSignal: (event) => ({
+    type: "file.changed",
+    ts: Date.now(),
+    id: crypto.randomUUID(),
+    payload: { path: event.path, event: event.type },
+  }),
+});
+
+// Start watching — file changes flow through the bus to your handlers
+await watcher.start((signal) => bus.emit(signal));
+```
+
+## Complete Example
+
+```typescript
+import {
+  createSignalBus,
+  createFileWatcherSource,
+  type DefineSignals,
+} from "@peleke.s/cadence";
+
+type MySignals = DefineSignals<{
+  "file.changed": { path: string; event: "add" | "change" | "unlink" };
+}>;
+
+const bus = createSignalBus<MySignals>();
+
+bus.on("file.changed", async (signal) => {
+  console.log(`[${signal.payload.event}] ${signal.payload.path}`);
+});
+
+const watcher = createFileWatcherSource<MySignals>({
+  paths: ["./notes"],
+  toSignal: (event) => ({
+    type: "file.changed",
+    ts: Date.now(),
+    id: crypto.randomUUID(),
+    payload: { path: event.path, event: event.type },
+  }),
+});
+
+await watcher.start((signal) => bus.emit(signal));
+
+// Now modify a file in ./notes and watch the console
+```
+
+## What's Next?
+
+- [Core Concepts](concepts.md) — understand the pluggable architecture
+- [Signal Bus Guide](../guides/signal-bus.md) — middleware, replay, error handling
+- [Sources Guide](../guides/sources.md) — file watcher and cron scheduling
+- [Clock System Guide](../guides/clocks.md) — interval timers, testing, and bridging

--- a/docs/guides/clocks.md
+++ b/docs/guides/clocks.md
@@ -1,0 +1,233 @@
+# Clock System
+
+Clocks are timing primitives that tick at a rate and invoke a handler. They are lower-level than sources — use `createClockSource` to adapt a clock into a `Source<S>` for the signal bus.
+
+## Clock Interface
+
+```typescript
+interface Clock {
+  start(handler: TickHandler): void;
+  stop(): void;
+  now(): number;
+  stats(): TickStats;
+  readonly running: boolean;
+  readonly seq: number;
+}
+```
+
+Every clock emits `Tick` objects:
+
+```typescript
+interface Tick {
+  ts: number;    // Unix timestamp (ms)
+  seq: number;   // Monotonic counter, 0-based
+  reason: "interval" | "bridge" | "manual" | "catchup";
+  drift?: number; // Ms from ideal fire time (interval clocks only)
+}
+```
+
+## Interval Clock
+
+Production timer using chained `setTimeout` (never `setInterval`). Supports three backpressure policies.
+
+### Basic Usage
+
+```typescript
+import { createIntervalClock } from "@peleke.s/cadence";
+
+const clock = createIntervalClock({ intervalMs: 1000 });
+
+clock.start(async (tick) => {
+  console.log(`Tick #${tick.seq} at ${tick.ts}`);
+});
+
+// Later:
+clock.stop();
+```
+
+### Configuration
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `intervalMs` | `number` | — | Interval between ticks in milliseconds |
+| `backpressure` | `BackpressurePolicy` | `"block"` | How to handle slow handlers |
+| `maxCatchUpTicks` | `number` | `3` | Max catch-up ticks per cycle (drop/adaptive) |
+| `onDriftWarning` | `(driftMs: number) => void` | — | Called when drift exceeds 80% of interval for 5+ ticks |
+| `onError` | `(error: unknown) => void` | — | Called when handler throws |
+
+### Backpressure Policies
+
+#### Block (Default)
+
+Fixed-delay scheduling. The next tick is scheduled after the handler completes plus `intervalMs`. This prevents spiral-of-death by construction — if the handler is slow, ticks simply space out.
+
+```typescript
+const clock = createIntervalClock({
+  intervalMs: 1000,
+  backpressure: "block",
+});
+```
+
+#### Drop
+
+Fixed-rate scheduling. Ticks fire on schedule regardless of handler duration. If the handler is still running when the next tick is due, that tick is dropped. Dropped ticks are counted in stats.
+
+```typescript
+const clock = createIntervalClock({
+  intervalMs: 1000,
+  backpressure: "drop",
+});
+```
+
+After the handler finishes, the clock will fire catch-up ticks (up to `maxCatchUpTicks`) for any time that elapsed during the handler. If still behind after catch-up, remaining ticks are skipped to prevent spiral-of-death.
+
+#### Adaptive
+
+Fixed-rate with self-correction. An accumulator tracks overrun time, and the next delay is adjusted: `nextDelay = max(0, intervalMs - accumulated)`. Like drop, it fires catch-up ticks and clamps the accumulator to prevent runaway.
+
+```typescript
+const clock = createIntervalClock({
+  intervalMs: 1000,
+  backpressure: "adaptive",
+});
+```
+
+### Observability
+
+```typescript
+const stats = clock.stats();
+// {
+//   tickCount: 100,
+//   droppedTicks: 2,
+//   errors: 0,
+//   avgHandlerMs: 12.5,
+//   avgDriftMs: 1.3,
+//   lastTickAt: 1706900000000,
+//   maxHandlerMs: 45,
+// }
+```
+
+## Test Clock
+
+Deterministic clock for testing. No real timers — you control time manually.
+
+### Basic Usage
+
+```typescript
+import { createTestClock } from "@peleke.s/cadence";
+
+const clock = createTestClock(1000); // 1s interval
+
+const ticks: Tick[] = [];
+clock.start((tick) => { ticks.push(tick); });
+
+// Fire 3 ticks manually
+await clock.tick(3);
+
+console.log(ticks.length); // 3
+console.log(clock.now());  // 3000 (virtual time)
+console.log(clock.seq);    // 3
+```
+
+### API
+
+| Method | Description |
+|--------|-------------|
+| `tick(count?)` | Fire `count` ticks (default: 1). Advances virtual time by `count * intervalMs`. |
+| `advanceBy(ms)` | Advance virtual time by `ms`. Fires `Math.floor(ms / intervalMs)` ticks. Residual stays in accumulator. |
+| `flush()` | Fire one tick for any remaining accumulator time. |
+| `reset()` | Reset to t=0, seq=0, clear accumulator and stats. |
+| `pendingTicks` | Number of whole ticks pending in the accumulator. |
+
+### Key Properties
+
+- `now()` returns virtual time, never `Date.now()`
+- `start()` registers the handler but does NOT auto-tick
+- No drift, no dropped ticks — every tick fires
+- Handler errors are rethrown (not swallowed) so tests can catch them
+
+### Testing Pattern
+
+```typescript
+import { createTestClock, createClockSource, type DefineSignals } from "@peleke.s/cadence";
+
+type Signals = DefineSignals<{
+  "heartbeat": { seq: number };
+}>;
+
+const clock = createTestClock(5000);
+const source = createClockSource<Signals>({
+  clock,
+  toSignal: (tick) => ({
+    type: "heartbeat",
+    ts: tick.ts,
+    id: `test-${tick.seq}`,
+    payload: { seq: tick.seq },
+  }),
+});
+
+const emitted: Signals[] = [];
+await source.start(async (signal) => { emitted.push(signal); });
+
+await clock.tick(3);
+console.log(emitted.length); // 3
+```
+
+## Bridge Clock
+
+Adapts external events into clock ticks. Each `push()` call produces one tick. No interval configuration — timing comes entirely from the external system.
+
+### Basic Usage
+
+```typescript
+import { createBridgeClock } from "@peleke.s/cadence";
+
+const clock = createBridgeClock();
+
+clock.start(async (tick) => {
+  console.log(`Bridge tick #${tick.seq} reason: ${tick.reason}`);
+});
+
+// Push ticks from an external system
+clock.push();  // Tick #0
+clock.push();  // Tick #1
+```
+
+### Integration Pattern
+
+The bridge clock is designed for adapting external heartbeats or event loops:
+
+```typescript
+import { createBridgeClock, createClockSource } from "@peleke.s/cadence";
+
+const bridge = createBridgeClock();
+const source = createClockSource({
+  clock: bridge,
+  toSignal: (tick) => ({
+    type: "external.heartbeat",
+    ts: tick.ts,
+    id: crypto.randomUUID(),
+    payload: { seq: tick.seq },
+  }),
+});
+
+await source.start((signal) => bus.emit(signal));
+
+// In your external system's heartbeat callback:
+externalSystem.on("heartbeat", () => {
+  bridge.push();
+});
+```
+
+### Key Properties
+
+- Every `push()` = one tick with reason `"bridge"`
+- `now()` returns `Date.now()` (real time)
+- Never drops ticks — every push fires
+- No drift concept — timing is external
+- `push()` is a no-op if the clock is not running
+
+## See Also
+
+- [Sources](sources.md) — `createClockSource` adapter
+- [Types Reference](../reference/types.md#clock) — `Clock`, `Tick`, `TickStats` definitions

--- a/docs/guides/pluggable-layers.md
+++ b/docs/guides/pluggable-layers.md
@@ -1,0 +1,154 @@
+# Pluggable Layers
+
+Cadence's bus delegates three concerns to pluggable interfaces: how signals move (transport), how signals are persisted (store), and how handlers are executed (executor). Each has a default implementation and can be swapped independently.
+
+## Transport
+
+The transport controls how signals move from emitter to subscribers.
+
+### Interface
+
+```typescript
+interface Transport<S extends BaseSignal> {
+  emit(signal: S): Promise<void>;
+  subscribe(handler: AnySignalHandler<S>): () => void;
+}
+```
+
+### Default: Memory Transport
+
+Synchronous in-process delivery. All subscribers are called in the same event loop tick as the emitter.
+
+```typescript
+import { createMemoryTransport } from "@peleke.s/cadence";
+
+const transport = createMemoryTransport<MySignals>();
+```
+
+### Custom Transport
+
+Replace with Redis, WebSocket, HTTP, or any other delivery mechanism:
+
+```typescript
+const redisTransport: Transport<MySignals> = {
+  async emit(signal) {
+    await redis.publish("signals", JSON.stringify(signal));
+  },
+  subscribe(handler) {
+    const sub = redis.subscribe("signals", (msg) => {
+      handler(JSON.parse(msg));
+    });
+    return () => sub.unsubscribe();
+  },
+};
+
+const bus = createSignalBus<MySignals>({ transport: redisTransport });
+```
+
+## Store
+
+The store provides persistence for durability and signal replay.
+
+### Interface
+
+```typescript
+interface SignalStore<S extends BaseSignal> {
+  save(signal: S): Promise<void>;
+  markAcked(signalId: string): Promise<void>;
+  getUnacked(): Promise<S[]>;
+}
+```
+
+The bus calls `save()` before processing, `markAcked()` after successful processing, and `getUnacked()` during `replay()`.
+
+### Default: Noop Store
+
+No persistence. Signals are not saved, `getUnacked()` always returns `[]`, and `replay()` is a no-op.
+
+```typescript
+import { createNoopStore } from "@peleke.s/cadence";
+
+const store = createNoopStore<MySignals>();
+```
+
+### Custom Store
+
+```typescript
+const sqliteStore: SignalStore<MySignals> = {
+  async save(signal) {
+    await db.insert("signals", { id: signal.id, data: JSON.stringify(signal), acked: false });
+  },
+  async markAcked(signalId) {
+    await db.update("signals", { acked: true }, { id: signalId });
+  },
+  async getUnacked() {
+    const rows = await db.select("signals", { acked: false });
+    return rows.map((r) => JSON.parse(r.data));
+  },
+};
+
+const bus = createSignalBus<MySignals>({ store: sqliteStore });
+
+// On restart, replay missed signals:
+const count = await bus.replay();
+console.log(`Replayed ${count} signals`);
+```
+
+## Executor
+
+The executor controls handler concurrency — how handlers are invoked.
+
+### Interface
+
+```typescript
+interface HandlerExecutor<S extends BaseSignal> {
+  execute(handler: AnySignalHandler<S>, signal: S): Promise<void>;
+  stats(): { queued: number; processing: number };
+}
+```
+
+### Default: Sequential Executor
+
+Handlers run one at a time, in order. Each handler completes before the next starts.
+
+```typescript
+import { createSequentialExecutor } from "@peleke.s/cadence";
+
+const executor = createSequentialExecutor<MySignals>();
+```
+
+### Custom Executor
+
+```typescript
+const concurrentExecutor: HandlerExecutor<MySignals> = {
+  async execute(handler, signal) {
+    // Fire and forget — handlers run concurrently
+    handler(signal).catch(console.error);
+  },
+  stats() {
+    return { queued: 0, processing: 0 };
+  },
+};
+
+const bus = createSignalBus<MySignals>({ executor: concurrentExecutor });
+```
+
+## Composition Example
+
+Combine all three for a durable, distributed setup:
+
+```typescript
+const bus = createSignalBus<MySignals>({
+  transport: createRedisTransport(),
+  store: createSqliteStore("./signals.db"),
+  executor: createSequentialExecutor(),
+  onError: (signal, handler, err) => {
+    logger.error({ signal: signal.type, handler, err }, "Handler failed");
+  },
+});
+```
+
+## See Also
+
+- [Signal Bus](signal-bus.md) — bus usage, middleware, replay
+- [Types Reference](../reference/types.md#transport) — full interface definitions

--- a/docs/guides/signal-bus.md
+++ b/docs/guides/signal-bus.md
@@ -1,0 +1,171 @@
+# Signal Bus
+
+The signal bus is the core of Cadence. It coordinates signal routing, middleware, persistence, and handler execution.
+
+## Creating a Bus
+
+```typescript
+import { createSignalBus, type DefineSignals } from "@peleke.s/cadence";
+
+type MySignals = DefineSignals<{
+  "file.changed": { path: string };
+  "task.created": { title: string; assignee: string };
+}>;
+
+const bus = createSignalBus<MySignals>();
+```
+
+All options are optional — defaults provide in-memory transport, no persistence, and sequential execution:
+
+```typescript
+import {
+  createSignalBus,
+  createMemoryTransport,
+  createNoopStore,
+  createSequentialExecutor,
+} from "@peleke.s/cadence";
+
+// These are the defaults (shown explicitly)
+const bus = createSignalBus<MySignals>({
+  transport: createMemoryTransport(),
+  store: createNoopStore(),
+  executor: createSequentialExecutor(),
+  onError: (signal, handlerName, error) => {
+    console.error(`Handler ${handlerName} failed on ${signal.type}:`, error);
+  },
+});
+```
+
+## Subscribing to Signals
+
+### Type-Specific Handlers
+
+Subscribe to a specific signal type. The handler receives only signals matching that type, with full type narrowing:
+
+```typescript
+bus.on("file.changed", async (signal) => {
+  // signal.payload is { path: string } — fully typed
+  console.log(signal.payload.path);
+});
+```
+
+The return value is an unsubscribe function:
+
+```typescript
+const unsub = bus.on("task.created", handler);
+// Later:
+unsub();
+```
+
+### Any Handlers
+
+Subscribe to all signals regardless of type:
+
+```typescript
+bus.onAny(async (signal) => {
+  console.log(`[${signal.type}] ${JSON.stringify(signal.payload)}`);
+});
+```
+
+## Emitting Signals
+
+```typescript
+await bus.emit({
+  type: "task.created",
+  ts: Date.now(),
+  id: crypto.randomUUID(),
+  payload: { title: "Review PR", assignee: "alice" },
+});
+```
+
+The emit flow:
+
+1. Signal saved to store (for durability)
+2. Signal dispatched through transport
+3. Middleware chain runs (if any)
+4. Type-specific handlers execute
+5. Any-handlers execute
+6. Signal marked as acknowledged in store
+
+## Middleware
+
+Middleware runs before handlers. It receives the signal and a `next()` function:
+
+```typescript
+// Logging middleware
+bus.use(async (signal, next) => {
+  console.log(`→ ${signal.type}`);
+  await next();
+  console.log(`← ${signal.type}`);
+});
+
+// Filtering middleware (skip signals by returning without calling next)
+bus.use(async (signal, next) => {
+  if (signal.type === "file.changed" && signal.payload.path.endsWith(".tmp")) {
+    return; // Drop temp file signals
+  }
+  await next();
+});
+
+// Enrichment middleware
+bus.use(async (signal, next) => {
+  signal.source = signal.source ?? "default";
+  await next();
+});
+```
+
+Middleware runs in registration order. The last middleware's `next()` invokes the handlers.
+
+## Signal Replay
+
+If you provide a store that persists signals, you can replay unacknowledged signals on restart:
+
+```typescript
+const replayed = await bus.replay();
+console.log(`Replayed ${replayed} signals`);
+```
+
+This fetches all unacked signals from the store, re-emits them through the transport, and marks them as acknowledged.
+
+## Statistics
+
+Monitor bus activity:
+
+```typescript
+const stats = bus.stats();
+// {
+//   emitted: 42,
+//   handled: 38,
+//   errors: 2,
+//   handlers: 3,
+//   anyHandlers: 1,
+//   middleware: 2,
+// }
+```
+
+## Error Handling
+
+Handler errors are caught by the bus and passed to the `onError` callback. They do not crash the bus or prevent other handlers from running:
+
+```typescript
+const bus = createSignalBus<MySignals>({
+  onError: (signal, handlerName, error) => {
+    // handlerName is "type:file.changed" or "any:0"
+    console.error(`Error in ${handlerName}:`, error);
+  },
+});
+```
+
+## Cleanup
+
+Remove all handlers and middleware:
+
+```typescript
+bus.clear();
+```
+
+## See Also
+
+- [Core Concepts](../getting-started/concepts.md) — architecture overview
+- [Pluggable Layers](pluggable-layers.md) — custom transport, store, executor
+- [Types Reference](../reference/types.md#signalbus) — full interface definitions

--- a/docs/guides/sources.md
+++ b/docs/guides/sources.md
@@ -1,0 +1,190 @@
+# Sources
+
+Sources produce signals from external events. Every source implements the `Source<S>` interface and follows the `toSignal` pattern — you provide a function that transforms raw events into your signal types.
+
+## Source Interface
+
+```typescript
+interface Source<S extends BaseSignal> {
+  name: string;
+  start(emit: (signal: S) => Promise<void>): Promise<void>;
+  stop(): Promise<void>;
+}
+```
+
+Call `start()` with an emit function (typically `(signal) => bus.emit(signal)`), and the source begins producing signals. Call `stop()` to shut it down.
+
+## File Watcher
+
+Watch the file system for changes using [chokidar](https://github.com/paulmillr/chokidar).
+
+### Basic Usage
+
+```typescript
+import { createFileWatcherSource, type DefineSignals } from "@peleke.s/cadence";
+
+type Signals = DefineSignals<{
+  "file.changed": { path: string; event: "add" | "change" | "unlink" };
+}>;
+
+const watcher = createFileWatcherSource<Signals>({
+  paths: ["./notes", "./tasks"],
+  toSignal: (event) => ({
+    type: "file.changed",
+    ts: Date.now(),
+    id: crypto.randomUUID(),
+    payload: { path: event.path, event: event.type },
+  }),
+});
+
+await watcher.start((signal) => bus.emit(signal));
+```
+
+### Configuration
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `paths` | `string \| string[]` | — | Paths to watch (files or directories) |
+| `events` | `FileEventType[]` | `["add", "change", "unlink"]` | Event types to listen for |
+| `toSignal` | `(event: FileEvent) => S \| null` | — | Transform file events into signals. Return `null` to skip. |
+| `chokidar` | object | `{}` | Chokidar options (see below) |
+
+### Chokidar Options
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `ignored` | `string \| RegExp \| function` | — | Paths to ignore |
+| `usePolling` | `boolean` | `false` | Use polling (for network drives) |
+| `interval` | `number` | — | Polling interval in ms |
+| `ignoreInitial` | `boolean` | `true` | Skip initial add events |
+| `awaitWriteFinish` | `boolean \| object` | — | Wait for writes to finish |
+
+### Filtering Events
+
+Return `null` from `toSignal` to skip an event:
+
+```typescript
+const watcher = createFileWatcherSource<Signals>({
+  paths: ["./src"],
+  events: ["change"], // Only watch changes, not add/unlink
+  toSignal: (event) => {
+    // Skip non-TypeScript files
+    if (!event.path.endsWith(".ts")) return null;
+
+    return {
+      type: "file.changed",
+      ts: event.ts,
+      id: crypto.randomUUID(),
+      payload: { path: event.path, event: event.type },
+    };
+  },
+});
+```
+
+### FileEvent Shape
+
+```typescript
+interface FileEvent {
+  type: "add" | "change" | "unlink";
+  path: string; // Absolute path
+  ts: number;   // Timestamp when event occurred
+}
+```
+
+## Cron Source
+
+Schedule signal emission using cron expressions. Uses [croner](https://github.com/hexagon/croner) — lightweight, timezone-aware, no native dependencies.
+
+### Basic Usage
+
+```typescript
+import { createCronSource, type DefineSignals } from "@peleke.s/cadence";
+
+type Signals = DefineSignals<{
+  "cron.fired": { jobId: string; jobName: string };
+}>;
+
+const cron = createCronSource<Signals>({
+  jobs: [
+    { id: "morning", name: "Morning Check", expr: "0 8 * * *", tz: "America/New_York" },
+    { id: "evening", name: "Evening Digest", expr: "0 18 * * *", tz: "America/New_York" },
+  ],
+  toSignal: (job, firedAt) => ({
+    type: "cron.fired",
+    ts: firedAt,
+    id: crypto.randomUUID(),
+    payload: { jobId: job.id, jobName: job.name },
+  }),
+});
+
+await cron.start((signal) => bus.emit(signal));
+```
+
+### Configuration
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `jobs` | `CronJob[]` | — | Jobs to schedule |
+| `toSignal` | `(job: CronJob, firedAt: number) => S` | — | Create a signal when a job fires |
+| `onFire` | `(job: CronJob) => void` | — | Called when a job fires (logging) |
+| `onError` | `(job: CronJob, error: Error) => void` | — | Called on cron parse error |
+
+### CronJob Shape
+
+```typescript
+interface CronJob {
+  id: string;       // Unique job identifier
+  name: string;     // Human-readable name
+  expr: string;     // Cron expression (e.g., "0 8 * * *")
+  tz?: string;      // Timezone (e.g., "America/New_York")
+  enabled?: boolean; // Default: true
+}
+```
+
+### Utility Functions
+
+```typescript
+import { getNextRun, isValidCronExpr } from "@peleke.s/cadence";
+
+// Check next run time
+const next = getNextRun("0 8 * * *", "America/New_York");
+console.log(next); // Date object or null if invalid
+
+// Validate an expression
+isValidCronExpr("0 8 * * *"); // true
+isValidCronExpr("not valid");  // false
+```
+
+## Clock Source Adapter
+
+Convert any `Clock` into a `Source<S>` using `createClockSource`:
+
+```typescript
+import { createIntervalClock, createClockSource, type DefineSignals } from "@peleke.s/cadence";
+
+type Signals = DefineSignals<{
+  "heartbeat": { seq: number };
+}>;
+
+const clock = createIntervalClock({ intervalMs: 5000 });
+
+const source = createClockSource<Signals>({
+  clock,
+  toSignal: (tick) => ({
+    type: "heartbeat",
+    ts: tick.ts,
+    id: crypto.randomUUID(),
+    payload: { seq: tick.seq },
+  }),
+});
+
+await source.start((signal) => bus.emit(signal));
+```
+
+This follows the same `toSignal` pattern as file watcher and cron sources, keeping the API consistent.
+
+## See Also
+
+- [Clock System](clocks.md) — interval, test, and bridge clocks
+- [Signal Bus](signal-bus.md) — connecting sources to the bus
+- [Types Reference](../reference/types.md#source) — `Source`, `FileEvent`, `CronJob` definitions

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,62 @@
+# Cadence
+
+**Typed event infrastructure for ambient AI agency.**
+
+Cadence is the nervous system for AI agents that watch, notice, and act without being asked. It provides a type-safe signal bus with pluggable transport, persistence, and execution layers.
+
+## Features
+
+- **Type-safe signals** — `DefineSignals<M>` creates discriminated unions from a simple map
+- **Pluggable architecture** — Swap transport, store, and executor independently
+- **Built-in sources** — File watcher (chokidar) and cron scheduler (croner) out of the box
+- **Clock system** — Interval, test, and bridge clocks with backpressure policies
+- **Middleware** — Transform, filter, or log signals before handlers run
+- **Signal replay** — Replay unacknowledged signals from store on restart
+
+## Quick Install
+
+```bash
+pnpm add @peleke.s/cadence
+```
+
+## Quick Example
+
+```typescript
+import {
+  createSignalBus,
+  createFileWatcherSource,
+  type DefineSignals,
+} from "@peleke.s/cadence";
+
+// 1. Define your signal types
+type Signals = DefineSignals<{
+  "file.changed": { path: string; event: "add" | "change" | "unlink" };
+}>;
+
+// 2. Create a bus
+const bus = createSignalBus<Signals>();
+
+// 3. Subscribe to signals
+bus.on("file.changed", async (signal) => {
+  console.log(`${signal.payload.event}: ${signal.payload.path}`);
+});
+
+// 4. Create a source and connect it
+const watcher = createFileWatcherSource<Signals>({
+  paths: ["./notes"],
+  toSignal: (event) => ({
+    type: "file.changed",
+    ts: Date.now(),
+    id: crypto.randomUUID(),
+    payload: { path: event.path, event: event.type },
+  }),
+});
+
+await watcher.start((signal) => bus.emit(signal));
+```
+
+## Next Steps
+
+- [Installation](getting-started/installation.md) — prerequisites and setup
+- [Quick Start](getting-started/quickstart.md) — build a working example in 5 minutes
+- [Core Concepts](getting-started/concepts.md) — understand the architecture

--- a/docs/reference/exports.md
+++ b/docs/reference/exports.md
@@ -1,0 +1,80 @@
+# API Exports
+
+Everything exported from `@peleke.s/cadence`:
+
+```typescript
+import {
+  // Bus
+  createSignalBus,
+
+  // Transport
+  createMemoryTransport,
+
+  // Store
+  createNoopStore,
+
+  // Executor
+  createSequentialExecutor,
+
+  // Sources
+  createFileWatcherSource,
+  createCronSource,
+  getNextRun,
+  isValidCronExpr,
+
+  // Clocks
+  createIntervalClock,
+  createTestClock,
+  createBridgeClock,
+  createClockSource,
+} from "@peleke.s/cadence";
+```
+
+## Functions
+
+| Function | Module | Description |
+|----------|--------|-------------|
+| `createSignalBus<S>(options?)` | bus | Create a typed signal bus |
+| `createMemoryTransport<S>()` | transport | Create an in-memory transport |
+| `createNoopStore<S>()` | store | Create a no-op (non-persisting) store |
+| `createSequentialExecutor<S>()` | executor | Create a sequential handler executor |
+| `createFileWatcherSource<S>(options)` | sources | Create a file-watching signal source |
+| `createCronSource<S>(options)` | sources | Create a cron-scheduled signal source |
+| `getNextRun(expr, tz?)` | sources | Get next run time for a cron expression |
+| `isValidCronExpr(expr)` | sources | Validate a cron expression |
+| `createIntervalClock(options)` | clock | Create a production interval clock |
+| `createTestClock(intervalMs?)` | clock | Create a deterministic test clock |
+| `createBridgeClock()` | clock | Create an external-event-driven clock |
+| `createClockSource<S>(options)` | clock | Adapt a Clock into a Source |
+
+## Types
+
+| Type | Module | Description |
+|------|--------|-------------|
+| `BaseSignal<T, P>` | types | Base signal shape |
+| `DefineSignals<M>` | types | Signal definition helper |
+| `SignalPayload<S, T>` | types | Extract payload type |
+| `SignalHandler<S, T>` | types | Type-specific handler |
+| `AnySignalHandler<S>` | types | Handler for all signals |
+| `Middleware<S>` | types | Middleware function |
+| `BusStats` | types | Bus statistics |
+| `Transport<S>` | types | Transport interface |
+| `SignalStore<S>` | types | Store interface |
+| `HandlerExecutor<S>` | types | Executor interface |
+| `Source<S>` | types | Signal source interface |
+| `SignalBus<S>` | bus | Bus interface |
+| `SignalBusOptions<S>` | bus | Bus configuration |
+| `FileEvent` | sources | File system event |
+| `FileEventType` | sources | `"add" \| "change" \| "unlink"` |
+| `FileWatcherOptions<S>` | sources | File watcher configuration |
+| `CronJob` | sources | Cron job definition |
+| `CronSourceOptions<S>` | sources | Cron source configuration |
+| `Tick` | clock | Single clock event |
+| `TickHandler` | clock | Clock tick handler |
+| `BackpressurePolicy` | clock | `"block" \| "drop" \| "adaptive"` |
+| `TickStats` | clock | Clock statistics |
+| `Clock` | clock | Core clock interface |
+| `IntervalClockOptions` | clock | Interval clock configuration |
+| `TestClock` | clock | Extended clock for testing |
+| `BridgeClock` | clock | Extended clock for external events |
+| `ClockSourceOptions<S>` | clock | Clock-to-source adapter configuration |

--- a/docs/reference/types.md
+++ b/docs/reference/types.md
@@ -53,7 +53,7 @@ type SignalPayload<S extends BaseSignal, T extends S["type"]> =
 Handler for a specific signal type.
 
 ```typescript
-type SignalHandler<S extends BaseSignal, T extends S["type"]> =
+type SignalHandler<S extends BaseSignal, T extends S["type"] = S["type"]> =
   (signal: Extract<S, { type: T }>) => void | Promise<void>;
 ```
 
@@ -96,7 +96,7 @@ interface BusStats {
 ### `SignalBus`
 
 ```typescript
-interface SignalBus<S extends BaseSignal> {
+interface SignalBus<S extends BaseSignal = BaseSignal> {
   emit(signal: S): Promise<void>;
   on<T extends S["type"]>(type: T, handler: SignalHandler<S, T>): () => void;
   onAny(handler: AnySignalHandler<S>): () => void;
@@ -110,7 +110,7 @@ interface SignalBus<S extends BaseSignal> {
 ### `SignalBusOptions`
 
 ```typescript
-interface SignalBusOptions<S extends BaseSignal> {
+interface SignalBusOptions<S extends BaseSignal = BaseSignal> {
   transport?: Transport<S>;
   store?: SignalStore<S>;
   executor?: HandlerExecutor<S>;
@@ -123,7 +123,7 @@ interface SignalBusOptions<S extends BaseSignal> {
 ### `Transport`
 
 ```typescript
-interface Transport<S extends BaseSignal> {
+interface Transport<S extends BaseSignal = BaseSignal> {
   emit(signal: S): Promise<void>;
   subscribe(handler: AnySignalHandler<S>): () => void;
 }
@@ -134,7 +134,7 @@ interface Transport<S extends BaseSignal> {
 ### `SignalStore`
 
 ```typescript
-interface SignalStore<S extends BaseSignal> {
+interface SignalStore<S extends BaseSignal = BaseSignal> {
   save(signal: S): Promise<void>;
   markAcked(signalId: string): Promise<void>;
   getUnacked(): Promise<S[]>;
@@ -146,7 +146,7 @@ interface SignalStore<S extends BaseSignal> {
 ### `HandlerExecutor`
 
 ```typescript
-interface HandlerExecutor<S extends BaseSignal> {
+interface HandlerExecutor<S extends BaseSignal = BaseSignal> {
   execute(handler: AnySignalHandler<S>, signal: S): Promise<void>;
   stats(): { queued: number; processing: number };
 }
@@ -157,7 +157,7 @@ interface HandlerExecutor<S extends BaseSignal> {
 ### `Source`
 
 ```typescript
-interface Source<S extends BaseSignal> {
+interface Source<S extends BaseSignal = BaseSignal> {
   name: string;
   start(emit: (signal: S) => Promise<void>): Promise<void>;
   stop(): Promise<void>;

--- a/docs/reference/types.md
+++ b/docs/reference/types.md
@@ -1,0 +1,315 @@
+# Type Reference
+
+All types exported from `@peleke.s/cadence`, organized by module.
+
+## Core Types
+
+### `BaseSignal`
+
+The base shape for all signals.
+
+```typescript
+interface BaseSignal<T extends string = string, P = unknown> {
+  type: T;         // Signal type identifier
+  ts: number;      // Unix timestamp (ms)
+  id: string;      // Unique signal ID
+  source?: string; // Origin identifier
+  payload: P;      // Signal-specific data
+}
+```
+
+### `DefineSignals`
+
+Type helper that creates a discriminated union from a signal map.
+
+```typescript
+type DefineSignals<M extends Record<string, unknown>> = {
+  [K in keyof M]: BaseSignal<K & string, M[K]>;
+}[keyof M];
+```
+
+**Usage:**
+
+```typescript
+type MySignals = DefineSignals<{
+  "file.changed": { path: string };
+  "cron.fired": { jobId: string };
+}>;
+// Equivalent to:
+// BaseSignal<"file.changed", { path: string }> | BaseSignal<"cron.fired", { jobId: string }>
+```
+
+### `SignalPayload`
+
+Extract the payload type for a specific signal type.
+
+```typescript
+type SignalPayload<S extends BaseSignal, T extends S["type"]> =
+  Extract<S, { type: T }>["payload"];
+```
+
+### `SignalHandler`
+
+Handler for a specific signal type.
+
+```typescript
+type SignalHandler<S extends BaseSignal, T extends S["type"]> =
+  (signal: Extract<S, { type: T }>) => void | Promise<void>;
+```
+
+### `AnySignalHandler`
+
+Handler for any signal.
+
+```typescript
+type AnySignalHandler<S extends BaseSignal> = (signal: S) => void | Promise<void>;
+```
+
+### `Middleware`
+
+Middleware function. Receives signal and `next()`.
+
+```typescript
+type Middleware<S extends BaseSignal> = (
+  signal: S,
+  next: () => Promise<void>,
+) => Promise<void>;
+```
+
+### `BusStats`
+
+Bus statistics for observability.
+
+```typescript
+interface BusStats {
+  emitted: number;      // Total signals emitted
+  handled: number;      // Total handler invocations
+  errors: number;       // Total handler errors caught
+  handlers: number;     // Registered type-specific handlers
+  anyHandlers: number;  // Registered any-handlers
+  middleware: number;    // Registered middleware
+}
+```
+
+## SignalBus
+
+### `SignalBus`
+
+```typescript
+interface SignalBus<S extends BaseSignal> {
+  emit(signal: S): Promise<void>;
+  on<T extends S["type"]>(type: T, handler: SignalHandler<S, T>): () => void;
+  onAny(handler: AnySignalHandler<S>): () => void;
+  use(middleware: Middleware<S>): void;
+  clear(): void;
+  stats(): BusStats;
+  replay(): Promise<number>;
+}
+```
+
+### `SignalBusOptions`
+
+```typescript
+interface SignalBusOptions<S extends BaseSignal> {
+  transport?: Transport<S>;
+  store?: SignalStore<S>;
+  executor?: HandlerExecutor<S>;
+  onError?: (signal: S, handlerName: string, error: unknown) => void;
+}
+```
+
+## Transport
+
+### `Transport`
+
+```typescript
+interface Transport<S extends BaseSignal> {
+  emit(signal: S): Promise<void>;
+  subscribe(handler: AnySignalHandler<S>): () => void;
+}
+```
+
+## Store
+
+### `SignalStore`
+
+```typescript
+interface SignalStore<S extends BaseSignal> {
+  save(signal: S): Promise<void>;
+  markAcked(signalId: string): Promise<void>;
+  getUnacked(): Promise<S[]>;
+}
+```
+
+## Executor
+
+### `HandlerExecutor`
+
+```typescript
+interface HandlerExecutor<S extends BaseSignal> {
+  execute(handler: AnySignalHandler<S>, signal: S): Promise<void>;
+  stats(): { queued: number; processing: number };
+}
+```
+
+## Source
+
+### `Source`
+
+```typescript
+interface Source<S extends BaseSignal> {
+  name: string;
+  start(emit: (signal: S) => Promise<void>): Promise<void>;
+  stop(): Promise<void>;
+}
+```
+
+### `FileEvent`
+
+```typescript
+interface FileEvent {
+  type: "add" | "change" | "unlink";
+  path: string;
+  ts: number;
+}
+```
+
+### `FileEventType`
+
+```typescript
+type FileEventType = "add" | "change" | "unlink";
+```
+
+### `FileWatcherOptions`
+
+```typescript
+interface FileWatcherOptions<S extends BaseSignal> {
+  paths: string | string[];
+  events?: FileEventType[];
+  toSignal: (event: FileEvent) => S | null;
+  chokidar?: {
+    ignored?: string | RegExp | ((path: string) => boolean);
+    usePolling?: boolean;
+    interval?: number;
+    ignoreInitial?: boolean;
+    awaitWriteFinish?: boolean | { stabilityThreshold?: number; pollInterval?: number };
+  };
+}
+```
+
+### `CronJob`
+
+```typescript
+interface CronJob {
+  id: string;
+  name: string;
+  expr: string;
+  tz?: string;
+  enabled?: boolean;
+}
+```
+
+### `CronSourceOptions`
+
+```typescript
+interface CronSourceOptions<S extends BaseSignal> {
+  jobs: CronJob[];
+  toSignal: (job: CronJob, firedAt: number) => S;
+  onFire?: (job: CronJob) => void;
+  onError?: (job: CronJob, error: Error) => void;
+}
+```
+
+## Clock
+
+### `Tick`
+
+```typescript
+interface Tick {
+  ts: number;
+  seq: number;
+  reason: "interval" | "bridge" | "manual" | "catchup";
+  drift?: number;
+}
+```
+
+### `TickHandler`
+
+```typescript
+type TickHandler = (tick: Tick) => void | Promise<void>;
+```
+
+### `BackpressurePolicy`
+
+```typescript
+type BackpressurePolicy = "block" | "drop" | "adaptive";
+```
+
+### `TickStats`
+
+```typescript
+interface TickStats {
+  tickCount: number;
+  droppedTicks: number;
+  errors: number;
+  avgHandlerMs: number;
+  avgDriftMs: number;
+  lastTickAt: number;
+  maxHandlerMs: number;
+}
+```
+
+### `Clock`
+
+```typescript
+interface Clock {
+  start(handler: TickHandler): void;
+  stop(): void;
+  now(): number;
+  stats(): TickStats;
+  readonly running: boolean;
+  readonly seq: number;
+}
+```
+
+### `IntervalClockOptions`
+
+```typescript
+interface IntervalClockOptions {
+  intervalMs: number;
+  backpressure?: BackpressurePolicy;
+  maxCatchUpTicks?: number;
+  onDriftWarning?: (driftMs: number) => void;
+  onError?: (error: unknown) => void;
+}
+```
+
+### `TestClock`
+
+```typescript
+interface TestClock extends Clock {
+  tick(count?: number): Promise<void>;
+  advanceBy(ms: number): Promise<void>;
+  flush(): Promise<void>;
+  reset(): void;
+  readonly pendingTicks: number;
+}
+```
+
+### `BridgeClock`
+
+```typescript
+interface BridgeClock extends Clock {
+  push(reason?: string): void;
+}
+```
+
+### `ClockSourceOptions`
+
+```typescript
+interface ClockSourceOptions<S extends BaseSignal> {
+  clock: Clock;
+  toSignal: (tick: Tick) => S;
+  name?: string;
+}
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,45 @@
+site_name: Cadence
+site_url: https://peleke.github.io/cadence/
+site_description: Typed event infrastructure for ambient AI agency
+repo_url: https://github.com/Peleke/cadence
+repo_name: Peleke/cadence
+
+theme:
+  name: readthedocs
+
+markdown_extensions:
+  - admonition
+  - attr_list
+  - md_in_html
+  - tables
+  - toc:
+      permalink: true
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
+  - pymdownx.inlinehilite
+  - pymdownx.tabbed:
+      alternate_style: true
+
+extra_javascript:
+  - https://unpkg.com/mermaid@11/dist/mermaid.min.js
+
+nav:
+  - Home: index.md
+  - Getting Started:
+    - Installation: getting-started/installation.md
+    - Quick Start: getting-started/quickstart.md
+    - Core Concepts: getting-started/concepts.md
+  - Guides:
+    - Signal Bus: guides/signal-bus.md
+    - Sources: guides/sources.md
+    - Clock System: guides/clocks.md
+    - Pluggable Layers: guides/pluggable-layers.md
+  - Reference:
+    - Types: reference/types.md
+    - API Exports: reference/exports.md
+  - Changelog: changelog.md

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+mkdocs>=1.6,<2
+pymdown-extensions>=10.14


### PR DESCRIPTION
## Summary

- Complete MkDocs documentation site with ReadTheDocs theme
- 11 documentation pages covering all Cadence APIs
- GitHub Actions workflow for automatic deployment to GitHub Pages
- Architecture diagrams (mermaid), code examples, and type reference

### Pages

| Section | Pages |
|---------|-------|
| Getting Started | Installation, Quick Start, Core Concepts |
| Guides | Signal Bus, Sources, Clock System, Pluggable Layers |
| Reference | All Types, API Exports |
| Meta | Changelog |

### CI/CD

- Deploys on push to `main` when `docs/`, `mkdocs.yml`, or `requirements.txt` change
- Uses `actions/deploy-pages@v4` (modern approach, no gh-pages branch)
- Build with `--strict` to catch broken links

## Test plan

- [x] `mkdocs build --strict` passes with zero warnings
- [x] All internal links resolve
- [x] All code examples use correct import paths
- [ ] GitHub Pages enabled via `gh api`
- [ ] Site loads at https://peleke.github.io/cadence/

🤖 Generated with [Claude Code](https://claude.com/claude-code)